### PR TITLE
s3 connector - don't silently fail if there are problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,12 @@ In order to test uploading files through the web interface, you will need to con
 
 * `s3_config.json` - JSON file with the endpoint url and keys for uploading data.
 * `.dds-cli.json` - Username and password credentials for DDS authentication when uploading data _(NOTE: will soon not be needed)_
-* `dds_app.cfg` - App config file specifying the following:
-  * `DDS_S3_CONFIG="/code/dds_web/sensitive/s3_config.json"` - to tell the app where to find the above file _(NOTE: will soon not be needed)_
-  * `DDS_SAFE_SPRING_PROJECT` - the s3 project name to use
+* `dds_app.cfg` - App config file that should look something like this:
+
+  ```bash
+  DDS_S3_CONFIG="/code/dds_web/sensitive/s3_config.json" # Tells the app where to find the s3_config.json file (NOTE: will soon not be needed)
+  DDS_SAFE_SPRING_PROJECT="PROJECT-NAME" # The s3 project name to use. Please ask one of the core developers for this value.
+  ```
 
 Note that uploads with the default projects shipped in the development database will probably not work.
 You will need to create a new project first, then use that for testing.

--- a/dds_web/api/api_s3_connector.py
+++ b/dds_web/api/api_s3_connector.py
@@ -79,37 +79,37 @@ class ApiS3Connector:
     def get_s3_info(self):
         """Get information required to connect to cloud."""
 
-        safespring = ""
+        safespring_project = None
         from dds_web.api.db_connector import DBConnector
 
         with DBConnector() as dbconn:
-            safespring, error = dbconn.cloud_project()
+            safespring_project, error = dbconn.cloud_project()
+        assert safespring_project
 
-        app.logger.debug(safespring)
-
-        s3keys, url, bucketname, error = (None,) * 3 + ("",)
+        s3keys = {}
+        bucketname = None
+        error = ("",)
         # 1. Get keys
         # TODO (ina): Change -- these should not be saved in file
         # print(flask.current_app.config["DDS_S3_CONFIG"], flush=True)
         s3path = pathlib.Path(flask.current_app.config["DDS_S3_CONFIG"])
         # s3path = pathlib.Path.cwd() / pathlib.Path("sensitive/s3_config.json")
         with s3path.open(mode="r") as f:
-            s3keys = json.load(f).get("sfsp_keys").get(safespring)
-            app.logger.debug("keys: %s", s3keys)
+            s3keys = json.load(f)["sfsp_keys"][safespring_project]
 
         # 2. Get endpoint url
         with s3path.open(mode="r") as f:
             endpoint_url = json.load(f)["endpoint_url"]
-            app.logger.debug("Endpoint: %s", endpoint_url)
 
-        assert all(x in s3keys for x in ["access_key", "secret_key"]), "Keys not found!"
+        assert "access_key" in s3keys, "s3 access key not found!"
+        assert "secret_key" in s3keys, "s3 secret key not found!"
 
         with DBConnector() as dbconn:
             # 3. Get bucket name
             bucketname, error = dbconn.get_bucket_name()
 
         print(s3keys, flush=True)
-        return safespring, s3keys, endpoint_url, bucketname, error
+        return safespring_project, s3keys, endpoint_url, bucketname, error
 
     def get_safespring_project(self):
         """Get the safespring project"""

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -19,8 +19,8 @@ class Config(object):
     UPLOAD_FOLDER = "/dds_web/uploads"
     DOWNLOAD_FOLDER = "/dds_web/downloads"
     LOCAL_TEMP_CACHE = "/dds_web/local_temp_cache"
-    DDS_S3_CONFIG = "/code/dds_web/s3_config_example.json"
-    DDS_SAFE_SPRING_PROJECT = "YOUR-PROJECT-ID"
+    DDS_S3_CONFIG = "/code/dds_web/s3_config.json"
+    DDS_SAFE_SPRING_PROJECT = "SAFESPRING-PROJECT-NOT-SET"
 
     # Devel settings
     TEMPLATES_AUTO_RELOAD = True


### PR DESCRIPTION
PR comes as a result of me trying to hunt down an issue when running in development. After working backwards I finally got to this:

```
No such file or directory: '/code/dds_web/s3_config_example.json'
```

Which is fairly self explanatory and easy to fix. However, the code here and in `dds_cli` was catching these exceptions and setting a message. I'm not sure what happens to those messages, but because the exception is caught, the server returns a 200 status as if everything is fine - just without the required credentials. This in turn made the CLI fail which had the same code pattern. Finally I ended up with a pretty obscure error when the code tried to use the credentials later on in the execution.

Here, instead of silently failing if there are problems, I raise an exception. This is caught along with other possible exceptions and a HTML 500 status is returned.

See also https://github.com/ScilifelabDataCentre/dds_cli/pull/87