### PR TITLE
Use Node 14 for the ccs builder

### DIFF
--- a/Dockerfiles/nodebuilder.Dockerfile
+++ b/Dockerfiles/nodebuilder.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15-alpine
+FROM node:14-alpine
 RUN mkdir /build
 WORKDIR /build
 RUN npm install -g npm@latest --quiet


### PR DESCRIPTION
Node 15 reached end of life in May, and is thus no longer available on Dockerhub. Use Node 14 (LTS release) instead.

If you already have `node_modules` from Node 15, the folder must be deleted before you can use this version.