### PR TITLE
OIDC support for logins

### DIFF
--- a/Dockerfiles/backend.Dockerfile
+++ b/Dockerfiles/backend.Dockerfile
@@ -2,8 +2,8 @@
 ## Compile dist CSS
 ##############################
 FROM node:15-alpine AS compile_css
-COPY ./dds_web /code/dds_web
-WORKDIR /code/dds_web/static
+COPY ./dds_web/static /code/
+WORKDIR /code/
 RUN npm install -g npm@latest --quiet
 RUN npm install --quiet
 RUN npm run css
@@ -15,14 +15,14 @@ RUN npm run css
 # Set official image -- parent image
 FROM python:latest
 
-# Copy the content to a code folder in container
-COPY . /code
-
-# Copy the compiled CSS from the first build step
-COPY --from=compile_css /code/dds_web/static /code/dds_web/static
-
 # Install some necessary systems packages
 RUN apt-get update && apt-get install -y gfortran libopenblas-dev liblapack-dev
+
+# Copy the content to a code folder in container
+COPY ./requirements.txt /code/requirements.txt
+
+# Copy the compiled CSS from the first build step
+COPY --from=compile_css /code/ /code/dds_web/static
 
 # Install all dependencies
 RUN pip3 install -r /code/requirements.txt && pip3 install gunicorn
@@ -31,6 +31,9 @@ RUN pip3 install -r /code/requirements.txt && pip3 install gunicorn
 ### TODO - Replace this with `dds_cli` when published to PyPI
 ### TODO - NOT FOR USE IN PRODUCTION! CURRENTLY USING DEV BRANCH
 RUN pip3 install git+https://github.com/ScilifelabDataCentre/dds_cli.git@dev
+
+# Copy the content to a code folder in container
+COPY . /code
 
 # Add code directory in pythonpath
 ENV PYTHONPATH /code

--- a/Dockerfiles/backend.Dockerfile
+++ b/Dockerfiles/backend.Dockerfile
@@ -22,19 +22,15 @@ COPY . /code
 COPY --from=compile_css /code/dds_web/static /code/dds_web/static
 
 # Install some necessary systems packages
-RUN apt-get update
-RUN apt-get install -y gfortran libopenblas-dev liblapack-dev
+RUN apt-get update && apt-get install -y gfortran libopenblas-dev liblapack-dev
 
 # Install all dependencies
-RUN pip3 install -r /code/requirements.txt
+RUN pip3 install -r /code/requirements.txt && pip3 install gunicorn
 
 # Install DDS CLI for web upload
 ### TODO - Replace this with `dds_cli` when published to PyPI
 ### TODO - NOT FOR USE IN PRODUCTION! CURRENTLY USING DEV BRANCH
 RUN pip3 install git+https://github.com/ScilifelabDataCentre/dds_cli.git@dev
-
-# Install gnuicorn
-RUN pip3 install gunicorn
 
 # Add code directory in pythonpath
 ENV PYTHONPATH /code

--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -62,11 +62,13 @@ def create_app():
     # ma.init_app(app)
 
     # initialize OIDC
-    oauth.register("default_login",
-                   client_secret=app.config.get("OIDC_CLIENT_SECRET"),
-                   client_id=app.config.get("OIDC_CLIENT_ID"),
-                   server_metadata_url=app.config.get("OIDC_ACCESS_TOKEN_URL"),
-                   client_kwargs={"scope": "openid profile email"})
+    oauth.register(
+        "default_login",
+        client_secret=app.config.get("OIDC_CLIENT_SECRET"),
+        client_id=app.config.get("OIDC_CLIENT_ID"),
+        server_metadata_url=app.config.get("OIDC_ACCESS_TOKEN_URL"),
+        client_kwargs={"scope": "openid profile email"},
+    )
 
     with app.app_context():  # Everything in here has access to sessions
         from dds_web import routes  # Import routes

--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -14,6 +14,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import func
 from flask_marshmallow import Marshmallow
 from logging.handlers import RotatingFileHandler
+from authlib.integrations import flask_client as auth_flask_client
 
 # Own modules
 
@@ -24,6 +25,7 @@ app = Flask(__name__, instance_relative_config=False)
 db = SQLAlchemy()
 ma = Marshmallow(app)
 C_TZ = pytz.timezone("Europe/Stockholm")
+oauth = auth_flask_client.OAuth(app)
 
 # FUNCTIONS ####################################################### FUNCTIONS #
 
@@ -58,6 +60,13 @@ def create_app():
 
     db.init_app(app)  # Initialize database
     # ma.init_app(app)
+
+    # initialize OIDC
+    oauth.register("default_login",
+                   client_secret=os.environ.get("OIDC_CLIENT_SECRET"),
+                   client_id=os.environ.get("OIDC_CLIENT_ID"),
+                   server_metadata_url=os.environ.get("OIDC_ACCESS_TOKEN_URL"),
+                   client_kwargs={"scope": "openid profile email"})
 
     with app.app_context():  # Everything in here has access to sessions
         from dds_web import routes  # Import routes

--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -63,9 +63,9 @@ def create_app():
 
     # initialize OIDC
     oauth.register("default_login",
-                   client_secret=os.environ.get("OIDC_CLIENT_SECRET"),
-                   client_id=os.environ.get("OIDC_CLIENT_ID"),
-                   server_metadata_url=os.environ.get("OIDC_ACCESS_TOKEN_URL"),
+                   client_secret=app.config.get("OIDC_CLIENT_SECRET"),
+                   client_id=app.config.get("OIDC_CLIENT_ID"),
+                   server_metadata_url=app.config.get("OIDC_ACCESS_TOKEN_URL"),
                    client_kwargs={"scope": "openid profile email"})
 
     with app.app_context():  # Everything in here has access to sessions

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -24,3 +24,8 @@ class Config(object):
 
     # Devel settings
     TEMPLATES_AUTO_RELOAD = True
+
+    # OIDC
+    OIDC_CLIENT_ID = ""
+    OIDC_CLIENT_SECRET = ""
+    OIDC_ACCESS_TOKEN_URL = ""

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -106,9 +106,7 @@ class User(db.Model):
     projects = db.relationship(
         "Project", secondary=project_users, backref=db.backref("users", lazy="dynamic")
     )
-    identifiers = db.relationship(
-        "Identifier", back_populates="user", cascade="all, delete-orphan"
-    )
+    identifiers = db.relationship("Identifier", back_populates="user", cascade="all, delete-orphan")
 
     def __repr__(self):
         """Called by print, creates representation of object"""

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -95,7 +95,6 @@ class User(db.Model):
     password = db.Column(db.String(120), unique=False, nullable=False)
     role = db.Column(db.String(50), unique=False, nullable=False)
     permissions = db.Column(db.String(5), unique=False, nullable=False, default="--l--")
-
     # Foreign keys
     # One facility can have many users
     facility_id = db.Column(db.Integer, db.ForeignKey("facilities.id"))
@@ -107,11 +106,37 @@ class User(db.Model):
     projects = db.relationship(
         "Project", secondary=project_users, backref=db.backref("users", lazy="dynamic")
     )
+    identifiers = db.relationship(
+        "Identifier", back_populates="user", cascade="all, delete-orphan"
+    )
 
     def __repr__(self):
         """Called by print, creates representation of object"""
 
         return f"<User {self.public_id}>"
+
+
+class Identifier(db.Model):
+    """
+    Data model for user identifiers for login.
+
+    Elixir identifiers consists of 58 characters (40 hex + "@elixir-europe.org").
+    """
+
+    # Table setup
+    __tablename__ = "identifiers"
+    __table_args__ = {"extend_existing": True}
+
+    # Columns
+    identifier = db.Column(db.String(58), primary_key=True, unique=True, nullable=False)
+    # Foreign keys
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), primary_key=True)
+    user = db.relationship("User", back_populates="identifiers")
+
+    def __repr__(self):
+        """Called by print, creates representation of object"""
+
+        return f"<Identifier {self.identifier}>"
 
 
 class File(db.Model):

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -128,9 +128,9 @@ class Identifier(db.Model):
     __table_args__ = {"extend_existing": True}
 
     # Columns
-    identifier = db.Column(db.String(58), primary_key=True, unique=True, nullable=False)
     # Foreign keys
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), primary_key=True)
+    identifier = db.Column(db.String(58), primary_key=True, unique=True, nullable=False)
     user = db.relationship("User", back_populates="identifiers")
 
     def __repr__(self):

--- a/dds_web/templates/components/login_form.html
+++ b/dds_web/templates/components/login_form.html
@@ -30,4 +30,8 @@
     {% endif %}
     <button type="submit" class="btn btn-success w-100 mb-2">Log In</button>
     <p class="text-center mb-1 small"><a class="text-muted text-decoration-none" href="#">Forgot your password?</a></p>
+
+    <p>
+      <a class="btn btn-primary mt-3 w-100" href="{{ url_for('user.oidc_login' )}}">Log In Using Open ID Connect</a>
+    </p>
 </form>

--- a/dds_web/user.py
+++ b/dds_web/user.py
@@ -2,7 +2,7 @@
 
 import flask
 from flask import render_template, request, current_app, session, redirect, url_for
-import sqlalchemy 
+import sqlalchemy
 
 from dds_web import timestamp, oauth
 from dds_web.api.login import ds_access
@@ -61,7 +61,7 @@ def login():
         return redirect(to_go_url)
 
 
-def do_login(session, identifier:str, password:str = "") -> bool:
+def do_login(session, identifier: str, password: str = "") -> bool:
     """
     Check if a user with matching identifier exists. If so, log in as that user.
 
@@ -89,7 +89,7 @@ def do_login(session, identifier:str, password:str = "") -> bool:
     if session["is_facility"]:
         facility_info = models.Facility.query.filter(
             models.Facility.id == account.facility_id
-        ).first()    
+        ).first()
 
         session["facility_name"] = facility_info.name
         session["facility_id"] = facility_info.id
@@ -106,7 +106,7 @@ def oidc_login():
     return client.authorize_redirect(redirect_uri)
 
 
-@user_blueprint.route('/login-oidc/authorize')
+@user_blueprint.route("/login-oidc/authorize")
 def oidc_authorize():
     """Authorize a login using OpenID Connect (e.g. Elixir AAI)."""
     client = oauth.create_client("default_login")
@@ -142,7 +142,7 @@ def logout():
 @login_required
 def user_page(loginname=None):
     """User home page"""
-    #return session
+    # return session
     if session.get("is_admin"):
         return redirect(url_for("admin.admin_page"))
     if session["is_facility"]:

--- a/dds_web/user.py
+++ b/dds_web/user.py
@@ -64,7 +64,7 @@ def login():
 def do_login(session, identifier:str, password:str = "") -> bool:
     """
     Check if a user with matching identifier exists. If so, log in as that user.
-    
+
     TODO:
       * Add support for passwords
 

--- a/dds_web/user.py
+++ b/dds_web/user.py
@@ -66,7 +66,6 @@ def oidc_login():
     client = oauth.create_client("default_login")
     if not client:
         return flask.Response(status=404)
-    flask.current_app.logger.error(client)
     redirect_uri = flask.url_for("user.oidc_authorize", _external=True)
     return client.authorize_redirect(redirect_uri)
 

--- a/dds_web/user.py
+++ b/dds_web/user.py
@@ -77,12 +77,13 @@ def do_login(session, identifier:str, password:str = "") -> bool:
         bool: Whether the login attempt succeeded.
     """
     try:
-        account = models.Identifier.query.filter(models.Identifier.identifier == identifier).first().user
+        account = models.Identifier.query.filter(models.Identifier.identifier == identifier).first()
     except sqlalchemy.exc.SQLAlchemyError:
         return False
+    user_info = account.user
 
     # Use the current login definitions for compatibility
-    session["current_user_id"] = account["id"]
+    session["current_user_id"] = user_info["id"]
     session["current_user"] = user_info["username"]
     session["current_user_id"] = user_info["id"]
     session["is_admin"] = user_info.get("admin", False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ PyNaCl==1.4.0
 pytz==2020.1
 PyJWT==v1.7.1
 zstandard
+authlib


### PR DESCRIPTION
Add support for login via OpenID Connect.

Adds a new table `Identifiers` with a mapping of `user_id` to `identifier`, intended to replace `User.username`.

On login, the system will compare the email from oidc to all identifiers in the table and log in as the corresponding user.

Adds the following configuration options:
```
OIDC_CLIENT_ID = ""
OIDC_CLIENT_SECRET = ""
OIDC_ACCESS_TOKEN_URL = ""
```
