### PR TITLE
Fix the *-light colours in dark mode

### DIFF
--- a/dds_web/static/scss/_custom.scss
+++ b/dds_web/static/scss/_custom.scss
@@ -3,10 +3,6 @@
   opacity: .65;
 }
 
-.bg-light {
-  background-color: #99999922 !important;
-}
-
 // New custom styles
 .filesize_badge {
     @extend .badge, .border, .fw-light, .font-monospace;

--- a/dds_web/static/scss/_variables.scss
+++ b/dds_web/static/scss/_variables.scss
@@ -21,6 +21,7 @@ $primary-alt: #045C64;
 $secondary-alt: #491F53;
 $success-alt: #A7C947; // TODO - A bit light for use as "success" for validation etc. Split into its own colour?
 $info-alt: #4C979F;
+$light-alt: #343a40; // $gray-800 but this is before the bootstrap variables are loaded
 
 $font-family-sans-serif:
   // Custom - Lato (as recommended by SciLifeLab style guide)


### PR DESCRIPTION
Better method for sorting the colours out in dark mode. Fixes a bunch of minor bugs where anything using *-light classes were not rendering well in dark mode.