### PR TITLE
Moving the schedulers to init

### DIFF
--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -143,9 +143,7 @@ def create_app():
         app.register_blueprint(api_blueprint, url_prefix="/api/v1")
 
         # Set-up the schedulers
-        from dds_web.utils import scheduler_wrapper
-
-        scheduler_wrapper()
+        dds_web.utils.scheduler_wrapper()
 
         return app
 

--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -134,7 +134,6 @@ def create_app():
     )
 
     app.cli.add_command(fill_db_wrapper)
-    app.cli.add_command(scheduler_wrapper)
 
     with app.app_context():  # Everything in here has access to sessions
         from dds_web.database import models
@@ -146,6 +145,8 @@ def create_app():
         from dds_web.api import api_blueprint
 
         app.register_blueprint(api_blueprint, url_prefix="/api/v1")
+
+        scheduler_wrapper()
 
         return app
 
@@ -167,8 +168,6 @@ def fill_db_wrapper():
 ####################################################################################################
 
 
-@click.command("start-schedulers")
-@flask.cli.with_appcontext
 def scheduler_wrapper():
     scheduler = BackgroundScheduler(
         {
@@ -182,7 +181,7 @@ def scheduler_wrapper():
     )
     flask.current_app.logger.info("Initiated main scheduler")
 
-    from dds_web.utils import invoice_units, remove_invoiced, remove_expired, permanent_delete
+    # from dds_web.utils import invoice_units, remove_invoiced, remove_expired, permanent_delete
 
     # Schedule invoicing calculations every 30 days
     # TODO (ina): Change to correct interval - 30 days
@@ -241,4 +240,4 @@ def scheduler_wrapper():
 
     # Print the currently scheduled jobs as verification:
     flask.current_app.logger.info("Currently scheduled jobs:")
-    scheduler.print_jobs()
+    flask.current_app.logger.info(scheduler.print_jobs())

--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -18,10 +18,6 @@ from logging.config import dictConfig
 from authlib.integrations import flask_client as auth_flask_client
 from flask_httpauth import HTTPBasicAuth, HTTPTokenAuth, MultiAuth
 
-# # imports related to scheduling
-import atexit
-from apscheduler.schedulers.background import BackgroundScheduler
-
 ####################################################################################################
 # GLOBAL VARIABLES ############################################################## GLOBAL VARIABLES #
 ####################################################################################################
@@ -146,6 +142,9 @@ def create_app():
 
         app.register_blueprint(api_blueprint, url_prefix="/api/v1")
 
+        # Set-up the schedulers
+        from dds_web.utils import scheduler_wrapper
+
         scheduler_wrapper()
 
         return app
@@ -161,83 +160,3 @@ def fill_db_wrapper():
 
     fill_db()
     flask.current_app.logger.info("DB filled")
-
-
-####################################################################################################
-# BACKGROUND SCHEDULER ###################################################### BACKGROUND SCHEDULER #
-####################################################################################################
-
-
-def scheduler_wrapper():
-    scheduler = BackgroundScheduler(
-        {
-            "apscheduler.jobstores.default": {
-                "type": "sqlalchemy",
-                # "url": flask.current_app.config.get("SQLALCHEMY_DATABASE_URI"),
-                "engine": db.engine,
-            },
-            "apscheduler.timezone": "Europe/Stockholm",
-        }
-    )
-    flask.current_app.logger.info("Initiated main scheduler")
-
-    # from dds_web.utils import invoice_units, remove_invoiced, remove_expired, permanent_delete
-
-    # Schedule invoicing calculations every 30 days
-    # TODO (ina): Change to correct interval - 30 days
-    scheduler.add_job(
-        invoice_units,
-        "cron",
-        id="calc_costs",
-        replace_existing=True,
-        month="1-12",
-        day="1-31",
-        hour="0",
-    )
-
-    # Schedule delete of rows in version table after a specific amount of time
-    # Currently: First of every month
-    scheduler.add_job(
-        remove_invoiced,
-        "cron",
-        id="remove_versions",
-        replace_existing=True,
-        month="1-12",
-        day="1",
-        hour="1",
-    )
-
-    # Schedule move of rows in files table after a specific amount of time
-    # to DeletedFiles (does not exist yet) table
-    # Currently: First of every month
-    scheduler.add_job(
-        remove_expired,
-        "cron",
-        id="remove_expired",
-        replace_existing=True,
-        month="1-12",
-        day="1",
-        hour="2",
-    )
-
-    # Schedule delete rows in expiredfiles table after a specific amount of time
-    # TODO (ina): Change interval - 1 day?
-    scheduler.add_job(
-        permanent_delete,
-        "cron",
-        id="permanent_delete",
-        replace_existing=True,
-        month="1-12",
-        day="1-31",
-        hour="3",
-    )
-
-    scheduler.start()
-    flask.current_app.logger.info("Started main scheduler")
-
-    # Shut down the scheduler when exiting the app
-    atexit.register(lambda: scheduler.shutdown())
-
-    # Print the currently scheduled jobs as verification:
-    flask.current_app.logger.info("Currently scheduled jobs:")
-    flask.current_app.logger.info(scheduler.print_jobs())

--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -163,20 +163,21 @@ def fill_db_wrapper():
     fill_db()
     flask.current_app.logger.info("DB filled")
 
-    ####################################################################################################
-    # BACKGROUND SCHEDULER #############################################################################
-    ####################################################################################################
 
-    scheduler = BackgroundScheduler(
-        {
-            "apscheduler.jobstores.default": {
-                "type": "sqlalchemy",
-                # "url": flask.current_app.config.get("SQLALCHEMY_DATABASE_URI"),
-                "engine": db.engine,
-            },
-            "apscheduler.timezone": "Europe/Stockholm",
-        }
-    )
+####################################################################################################
+# BACKGROUND SCHEDULER ###################################################### BACKGROUND SCHEDULER #
+####################################################################################################
+
+scheduler = BackgroundScheduler(
+    {
+        "apscheduler.jobstores.default": {
+            "type": "sqlalchemy",
+            # "url": flask.current_app.config.get("SQLALCHEMY_DATABASE_URI"),
+            "engine": db.engine,
+        },
+        "apscheduler.timezone": "Europe/Stockholm",
+    }
+)
 
 
 scheduler.print_jobs()

--- a/dds_web/utils.py
+++ b/dds_web/utils.py
@@ -275,9 +275,6 @@ def permanent_delete():
 # BACKGROUND SCHEDULER ###################################################### BACKGROUND SCHEDULER #
 ####################################################################################################
 
-# Mind this discussion on the intricate peculiarities of running APScheduler in combination with Flask
-# https://github.com/agronholm/apscheduler/issues/250
-
 
 def scheduler_wrapper():
 

--- a/dds_web/utils.py
+++ b/dds_web/utils.py
@@ -15,6 +15,12 @@ from contextlib import contextmanager
 import flask
 import sqlalchemy
 
+# # imports related to scheduling
+import atexit
+
+import werkzeug
+from apscheduler.schedulers.background import BackgroundScheduler
+
 # Own modules
 from dds_web.database import models
 from dds_web import db, C_TZ
@@ -264,3 +270,111 @@ def permanent_delete():
     flask.current_app.logger.debug(
         "Permanently deleting the expired files (not implemented atm, just scheduled function)"
     )
+
+
+####################################################################################################
+# BACKGROUND SCHEDULER ###################################################### BACKGROUND SCHEDULER #
+####################################################################################################
+
+# Mind this discussion on the intricate peculiarities of running APScheduler in combination with Flask
+# https://github.com/agronholm/apscheduler/issues/250
+
+
+def scheduler_wrapper():
+
+    # Flask in debug mode spawns a child process so that it can restart the process each time the code changes,
+    # the new child process initializes and starts a new APScheduler, causing the jobs to be created twice
+    # within in the same database table:
+    # pymysql.err.IntegrityError: (1062, "Duplicate entry 'calc_costs' for key 'PRIMARY'") error
+
+    # Apparently, the reload is done with a subprocess.call, so we have 2 different Python interpreters running at the same time!
+    # This also means that any if statement or replace_existing=FALSE paramenter in add_job() won't prevent these errors.
+    # This if statement hopefully solves the issue:
+
+    if flask.helpers.get_debug_flag() and not werkzeug.serving.is_running_from_reloader():
+        return
+
+    scheduler = BackgroundScheduler(
+        {
+            "apscheduler.jobstores.default": {
+                "type": "sqlalchemy",
+                # "url": flask.current_app.config.get("SQLALCHEMY_DATABASE_URI"),
+                "engine": db.engine,
+            },
+            "apscheduler.timezone": "Europe/Stockholm",
+        }
+    )
+    flask.current_app.logger.info("Initiated main scheduler")
+
+    # Schedule invoicing calculations every 30 days
+    # TODO (ina): Change to correct interval - 30 days
+    if not scheduler.get_job("calc_costs"):
+        flask.current_app.logger.info("Added job: calc_costs")
+        scheduler.add_job(
+            invoice_units,
+            "cron",
+            id="calc_costs",
+            replace_existing=False,
+            coalesce=True,  # when several run times are due, none the less run the rob only once
+            month="1-12",
+            day="1-31",
+            hour="0",
+        )
+
+    # Schedule delete of rows in version table after a specific amount of time
+    # Currently: First of every month
+    if not scheduler.get_job("remove_versions"):
+        flask.current_app.logger.info("Added job: remove_versions")
+        scheduler.add_job(
+            remove_invoiced,
+            "cron",
+            id="remove_versions",
+            replace_existing=False,
+            coalesce=True,  # when several run times are due, none the less run the rob only once
+            month="1-12",
+            day="1",
+            hour="1",
+        )
+
+    # Schedule move of rows in files table after a specific amount of time
+    # to DeletedFiles (does not exist yet) table
+    # Currently: First of every month
+    if not scheduler.get_job("remove_expired"):
+        flask.current_app.logger.info("Added job: remove_expired")
+        scheduler.add_job(
+            remove_expired,
+            "cron",
+            id="remove_expired",
+            replace_existing=False,
+            coalesce=True,
+            month="1-12",
+            day="1",
+            hour="2",
+        )
+
+    # Schedule delete rows in expiredfiles table after a specific amount of time
+    # TODO (ina): Change interval - 1 day?
+    if not scheduler.get_job("permanent_delete"):
+        flask.current_app.logger.info("Added job: permanent_delete")
+        scheduler.add_job(
+            permanent_delete,
+            "cron",
+            id="permanent_delete",
+            replace_existing=False,
+            coalesce=True,
+            month="1-12",
+            day="1-31",
+            hour="3",
+        )
+
+    scheduler.start()
+    flask.current_app.logger.info("Started main scheduler")
+
+    # Shut down the scheduler when exiting the app
+    atexit.register(lambda: scheduler.shutdown())
+
+    # Print the currently scheduled jobs as verification:
+    joblist = scheduler.get_jobs()
+    flask.current_app.logger.info("Currently scheduled jobs:")
+    for job in joblist:
+        flask.current_app.logger.info(f"{job}")

--- a/dds_web/utils.py
+++ b/dds_web/utils.py
@@ -17,9 +17,8 @@ import sqlalchemy
 
 # # imports related to scheduling
 import atexit
-
 import werkzeug
-from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.schedulers import background
 
 # Own modules
 from dds_web.database import models
@@ -294,7 +293,7 @@ def scheduler_wrapper():
     if flask.helpers.get_debug_flag() and not werkzeug.serving.is_running_from_reloader():
         return
 
-    scheduler = BackgroundScheduler(
+    scheduler = background.BackgroundScheduler(
         {
             "apscheduler.jobstores.default": {
                 "type": "sqlalchemy",
@@ -377,4 +376,4 @@ def scheduler_wrapper():
     joblist = scheduler.get_jobs()
     flask.current_app.logger.info("Currently scheduled jobs:")
     for job in joblist:
-        flask.current_app.logger.info(f"{job}")
+        flask.current_app.logger.info(f"Job: {job}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       dockerfile: Dockerfiles/backend.Dockerfile
       context: ./
     working_dir: /code
-    command: bash -c "flask init-dev-db && flask start-schedulers && flask run -h 0.0.0.0 -p 5000"
+    command: bash -c "flask init-dev-db && flask run -h 0.0.0.0 -p 5000"
     environment:
       - DDS_APP_CONFIG=/code/dds_web/sensitive/dds_app.cfg
       - FLASK_ENV=development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       dockerfile: Dockerfiles/backend.Dockerfile
       context: ./
     working_dir: /code
-    command: bash -c "flask init-dev-db && flask run -h 0.0.0.0 -p 5000"
+    command: bash -c "flask init-dev-db && flask start-schedulers && flask run -h 0.0.0.0 -p 5000"
     environment:
       - DDS_APP_CONFIG=/code/dds_web/sensitive/dds_app.cfg
       - FLASK_ENV=development

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pytz==2020.1
 zstandard
 authlib
 apscheduler
+werkzeug
 pytest==6.2.4
 Flask-HTTPAuth
 pyjwt==2.1.0


### PR DESCRIPTION
Addresses #522

Suggested changes:

  - Moved the scheduling from utils to init.
  - Spread the jobs more out over the night.

Testing:

 - Verified that all functions and required packaged are imported.
 - Further testing currently not possible because both, the upstream dev and my feature branch, crash the container with `dds_backend   | Error: No such command 'init-dev-db'.` in the logs. 
