### PR TITLE
Proof of concept for User model inheritance

### DIFF
--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -213,7 +213,7 @@ class UserProjects(flask_restful.Resource):
 class RemoveContents(flask_restful.Resource):
     """Removes all project contents."""
 
-    @auth.login_required
+    @auth.login_required(role=["unit_user", "unit_admin"])
     def delete(self):
         """Removes all project contents."""
 

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -34,7 +34,7 @@ class Config(object):
     DOWNLOAD_FOLDER = "/dds_web/downloads"
     LOCAL_TEMP_CACHE = "/dds_web/local_temp_cache"
     DDS_S3_CONFIG = "/code/dds_web/sensitive/s3_config.json"
-    DDS_SAFE_SPRING_PROJECT = os.environ.get("DDS_SAFE_SPRING_PROJECT")
+    DDS_SAFE_SPRING_PROJECT = os.environ.get("DDS_SAFE_SPRING_PROJECT", "dds.example.com")
 
     # Devel settings
     TEMPLATES_AUTO_RELOAD = True

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -122,7 +122,7 @@ class User(db.Model):
     def __repr__(self):
         """Called by print, creates representation of object"""
 
-        return f"<User {self.username}>"
+        return f"<User {self.username}:{self.role}>"
 
 
 class ResearchUser(User):
@@ -136,7 +136,8 @@ class ResearchUser(User):
         "polymorphic_identity": "research_user",
     }
 
-    def role():
+    @property
+    def role(self):
         return "researcher"
 
 
@@ -150,6 +151,13 @@ class UnitUser(User):
     __mapper_args__ = {
         "polymorphic_identity": "unit_user",
     }
+
+    @property
+    def role(self):
+        if self.admin:
+            return "unit_admin"
+        else:
+            return "unit_user"
 
 
 class Identifier(db.Model):

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -48,10 +48,7 @@ def get_user_roles(user):
 
 
 def get_user_roles_common(user):
-    if "a" in user.permissions:
-        return "admin"
-    else:
-        return "user"
+    return user.role
 
 
 @token_auth.verify_token


### PR DESCRIPTION
Just showing the idea in python.

1. The authentication is unaffected from what I can tell, the username and password is accessed just as before.
2. The role property works as in `current_user.role`
3. Queries can be based on either User, ResearchUser or UnitUser.

The role implementation below is an even more draft than the rest, so please ask if anything looks weird. I made a test using the `@auth.login_required(role=[])` method, but it needs more granularity as well as in the `verify` method already in place.