### PR TITLE
Replace pyjwt dependency with jwcrypto and user dict-key with sub in the token

### DIFF
--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -8,7 +8,8 @@
 import argon2
 import http
 import flask
-import jwt
+import json
+from jwcrypto import jwk, jwt
 
 # Own modules
 from dds_web.api.errors import AuthenticationError, AccessDeniedError
@@ -53,16 +54,15 @@ def get_user_roles_common(user):
 
 @token_auth.verify_token
 def verify_token(token):
-    try:
-        data = jwt.decode(token, flask.current_app.config.get("SECRET_KEY"), algorithms="HS256")
-        username = data.get("user")
-        if username:
-            user = models.User.query.get(username)
-            if user:
-                return user
-        return None
-    except jwt.DecodeError:
-        return None
+    key = jwk.JWK.from_password(flask.current_app.config.get("SECRET_KEY"))
+    jwttoken = jwt.JWT(key=key, jwt=token, algs=["HS256"])
+    data = json.loads(jwttoken.claims)
+    username = data.get("sub")
+    if username:
+        user = models.User.query.get(username)
+        if user:
+            return user
+    return None
 
 
 @basic_auth.verify_password

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ apscheduler
 werkzeug
 pytest==6.2.4
 Flask-HTTPAuth
-pyjwt==2.1.0
+jwcrypto
 pandas
 requests


### PR DESCRIPTION
As it can be found from https://jwt.io/libraries, jwcrypto is the best option for python development with all jwt features approved. pyjwt has some features not approved (cross mark) and some unclear (question mark). User dict-key is replaced with sub, which identifies the principal that is the subject of the JWT [https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2].

The changes are manually tested with token and project listing endpoints. All runs fine. Base64 encoded jwt headers and content are manually checked to include the intended values as well. Signature verification is manually tested by changing the key just before authenticating the user and it works correctly.