### PR TITLE
Fix foreign keys and relationships

### DIFF
--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -55,7 +55,7 @@ class Unit(db.Model):
     name = db.Column(db.String(255), unique=True, nullable=False)
     internal_ref = db.Column(db.String(50), unique=True, nullable=False)
     safespring = db.Column(db.String(255), unique=False, nullable=False)  # unique=True later
-    days_to_expire = db.Column(db.Integer, unique=False, nullable=False, default=30)
+    days_to_expire = db.Column(db.Integer, unique=False, nullable=False, default=90)
     counter = db.Column(db.Integer, unique=False, nullable=True)
 
     # Relationships

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -60,7 +60,7 @@ class Unit(db.Model):
 
     # Relationships
     # One unit can have many users
-    users = db.relationship("UnitUser", back_populates="unit")
+    users = db.relationship("UnitUser", backref="unit")
     # One unit can have many projects
     projects = db.relationship("Project", backref="responsible_unit")
     # One unit can have many invites
@@ -111,11 +111,10 @@ class Project(db.Model):
     # Relationships
     # One project can have many files
     files = db.relationship("File", backref="project")
+    # One project can have many expired files
     expired_files = db.relationship("ExpiredFile", backref="assigned_project")
     # One project can have many file versions
     file_versions = db.relationship("Version", backref="responsible_project")
-
-    # researchusers = db.relationship("ProjectUsers", back_populates="project")
 
     @property
     def safespring_project(self):
@@ -145,7 +144,7 @@ class User(db.Model):
     type = db.Column(db.String(20), unique=False, nullable=False)
 
     # One user can have many identifiers
-    identifiers = db.relationship("Identifier", back_populates="user", cascade="all, delete-orphan")
+    identifiers = db.relationship("Identifier", backref="user", cascade="all, delete-orphan")
     # One user can have many email addresses
     emails = db.relationship("Email", backref="user", lazy="dynamic", cascade="all, delete-orphan")
     # One user can create many projects
@@ -192,7 +191,6 @@ class UnitUser(User):
 
     # Foreign key and backref with infrastructure
     unit_id = db.Column(db.Integer, db.ForeignKey("units.id"), nullable=False)
-    unit = db.relationship("Unit", back_populates="users")
 
     is_admin = db.Column(db.Boolean, nullable=False, default=False)
 
@@ -252,7 +250,6 @@ class Identifier(db.Model):
     # Foreign keys
     username = db.Column(db.String(50), db.ForeignKey("users.username"), primary_key=True)
     identifier = db.Column(db.String(58), primary_key=True, unique=True, nullable=False)
-    user = db.relationship("User", back_populates="identifiers")
 
     def __repr__(self):
         """Called by print, creates representation of object"""
@@ -261,9 +258,7 @@ class Identifier(db.Model):
 
 
 class Email(db.Model):
-    """
-    Data model for user email addresses.
-    """
+    """Data model for user email addresses."""
 
     # Table setup
     __tablename__ = "emails"
@@ -298,7 +293,7 @@ class Invite(db.Model):
     unit_id = db.Column(db.Integer, db.ForeignKey("units.id"))
 
     # Columns
-    email = db.Column(db.String(254), unique=True, nullable=False)
+    email = db.Column(db.String(255), unique=True, nullable=False)
     role = db.Column(db.String(20), unique=False, nullable=False)
 
     def __repr__(self):

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -270,7 +270,7 @@ class Email(db.Model):
     # Foreign key: One user can have multiple email addresses.
     user_id = db.Column(db.String(50), db.ForeignKey("users.username"))
 
-    email = db.Column(db.String(255), unique=True, nullable=False)
+    email = db.Column(db.String(254), unique=True, nullable=False)
     primary = db.Column(db.Boolean, unique=False, nullable=False, default=False)
 
     def __repr__(self):
@@ -293,7 +293,7 @@ class Invite(db.Model):
     unit_id = db.Column(db.Integer, db.ForeignKey("units.id"))
 
     # Columns
-    email = db.Column(db.String(255), unique=True, nullable=False)
+    email = db.Column(db.String(254), unique=True, nullable=False)
     role = db.Column(db.String(20), unique=False, nullable=False)
 
     def __repr__(self):

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -29,11 +29,11 @@ class ProjectUsers(db.Model):
     user_id = db.Column(db.String(50), db.ForeignKey("researchusers.username"), primary_key=True)
 
     # Columns
-    owner = db.Column(db.Boolean, nullable=False, default=False)
+    owner = db.Column(db.Boolean, nullable=False, default=False, unique=False)
 
     # Relationships - many to many
-    project = db.relationship("Project", back_populates="researchusers")
-    researchuser = db.relationship("ResearchUser", back_populates="project_associations")
+    project = db.relationship("Project", backref="researchusers")
+    researchuser = db.relationship("ResearchUser", backref="project_associations")
 
 
 ####################################################################################################
@@ -115,7 +115,7 @@ class Project(db.Model):
     # One project can have many file versions
     file_versions = db.relationship("Version", backref="responsible_project")
 
-    researchusers = db.relationship("ProjectUsers", back_populates="project")
+    # researchusers = db.relationship("ProjectUsers", back_populates="project")
 
     @property
     def safespring_project(self):
@@ -167,7 +167,6 @@ class ResearchUser(User):
 
     # primary key and foreign key pointing to users
     username = db.Column(db.String(50), db.ForeignKey("users.username"), primary_key=True)
-    project_associations = db.relationship("ProjectUsers", back_populates="researchuser")
 
     @property
     def role(self):

--- a/dds_web/development/db_init.py
+++ b/dds_web/development/db_init.py
@@ -69,8 +69,8 @@ def fill_db():
     project_1_user_1_association = models.ProjectUsers(owner=False)
     # Connect research user to association row. = (not append) due to one user per ass. row
     project_1_user_1_association.researchuser = researchuser_1
-    # Connect research user to project. append (not =) due to many users per project
-    project_1.researchusers.append(project_1_user_1_association)
+    # Connect project to association row. = (not append) dye to one project per ass. row
+    project_1_user_1_association.project = project_1
 
     # Create second research user
     researchuser_2 = models.ResearchUser(
@@ -82,8 +82,8 @@ def fill_db():
     project_1_user_2_association = models.ProjectUsers(owner=True)
     # Connect research user to association row. = (not append) due to one user per ass. row
     project_1_user_2_association.researchuser = researchuser_2
-    # Connect research user to project. append (not =) due to many users per project
-    project_1.researchusers.append(project_1_user_2_association)
+    # Connect project to association row. = (not append) dye to one project per ass. row
+    project_1_user_2_association.project = project_1
 
     # Create first unit user
     unituser_1 = models.UnitUser(


### PR DESCRIPTION
Some of the relationships in the database were specified as `back_populates` and some as `backref`. Have changed to `backref` since it automatically updates the foreign key in the other table, and reduces the amount of code needed.

Example: 
```
class Unit(db.Model):
    """Data model for unit accounts."""

    # Relationships
    # One unit can have many users
    users = db.relationship("UnitUser", backref="unit")


class UnitUser(User):
    """Data model for unit user accounts"""

    # Foreign key and backref with infrastructure
    unit_id = db.Column(db.Integer, db.ForeignKey("units.id"), nullable=False)
```
This "creates a column" called `unit` in `UnitUser` which can be used to access the responsible unit, and you can create entries in the database in the following way:
```
new_unit = Unit(<all the columns>)
new_user = UnitUser(<all the columns except unit_id>)

new_user.unit = new_unit 

db.session.add(new_user)
db.session.commit()
```

This automatically adds `new_unit` to the database as well, and sets the `new_user.unit_id` automatically to `new_unit.id`.
For `back_populates` you also need to explicitly create the relationship in the `UnitUser` class: 
```
class Unit(db.Model):
    """Data model for unit accounts."""

    # Relationships
    # One unit can have many users
    users = db.relationship("UnitUser", back_populates="unit")
    

class UnitUser(User):
    """Data model for unit user accounts"""

    # Foreign key and backref with infrastructure
    unit_id = db.Column(db.Integer, db.ForeignKey("units.id"), nullable=False)
    unit = db.relationship("Unit", back_populates="users")
```

Backref simplifies.