### PR TITLE
Fix the display of Usage and Cost columns

### DIFF
--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -138,15 +138,16 @@ class UserProjects(flask_restful.Resource):
                 proj_gbhours, proj_cost = DBConnector().project_usage(p)
                 total_gbhours_db += proj_gbhours
                 total_cost_db += proj_cost
-
-                project_info.update({"Usage": proj_gbhours, "Cost": proj_cost})
+                # undo calculation of GBhours and return ByteHours
+                project_info.update({"Usage": proj_gbhours * 10e9, "Cost": proj_cost})
 
             all_projects.append(project_info)
 
         return_info = {
             "project_info": all_projects,
             "total_usage": {
-                "usage": total_gbhours_db,
+                # undo calculation of GBhours and return ByteHours
+                "usage": total_gbhours_db * 10e9,
                 "cost": total_cost_db,
             },
             "total_size": total_size,


### PR DESCRIPTION
Addresses #628 and corrects PR  #651, a previous attempt to solve the issue differently. 

- In order to display the GBhours and costs again, it was required to fix the user roles that would be allowed to list the project costs.
- In contrast to the previous PR, it currently retains the `utils.format_byte_size()` function because this PR now solely refactors the `/proj/list` endpoint and spares the `/files/list` and `/user/list endpoints `to simplify the review.
- _GBhours_ were renamed to _Usage_ to achieve consistency in the table. Doing this client-side would have complicated matters a lot due to the way the existing client-side code was written.
- Calculation of the GBhours was not touched because it is so deeply wired into the API code. Instead the calculation is reverted shortly before building the JSON to adhere to the philosophy of returning the most basic response possible.  Once the other endpoints have been updated it may be possible to simplify here.   