### PR TITLE
Fixed the faulty GBhours calculation

### DIFF
--- a/dds_web/api/db_connector.py
+++ b/dds_web/api/db_connector.py
@@ -11,6 +11,7 @@ import os
 # Installed
 import flask
 import sqlalchemy
+import datetime
 import pytz
 
 # Own modules
@@ -322,26 +323,26 @@ class DBConnector:
     @staticmethod
     def project_usage(project_object):
 
-        gbhours = 0.0
+        bhours = 0.0
         cost = 0.0
 
         tz = pytz.timezone("Europe/Stockholm")
         for v in project_object.file_versions:
             # Calculate hours of the current file
             time_deleted = (
-                tz.localize(v.time_deleted) if v.time_deleted else dds_web.utils.current_time()
+                tz.localize(v.time_deleted) if v.time_deleted else datetime.datetime.now(tz=tz)
             )
             time_uploaded = tz.localize(v.time_uploaded)
 
             file_hours = (time_deleted - time_uploaded).seconds / (60 * 60)
 
-            # Calculate GBHours, if statement to avoid zerodivision exception
-            gbhours += ((v.size_stored / 1e9) / file_hours) if file_hours else 0.0
+            # Calculate BHours
+            bhours += v.size_stored * file_hours
 
             # Calculate approximate cost per gbhour: kr per gb per month / (days * hours)
             cost_gbhour = 0.09 / (30 * 24)
 
             # Save file cost to project info and increase total unit cost
-            cost += gbhours * cost_gbhour
+            cost += bhours / 1e9 * cost_gbhour
 
-        return round(gbhours, 2), round(cost, 2)
+        return bhours, cost

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -219,7 +219,7 @@ class UserProjects(flask_restful.Resource):
         all_projects = list()
 
         # Total number of GB hours and cost saved in the db for the specific unit
-        total_gbhours_db = 0.0
+        total_bhours_db = 0.0
         total_cost_db = 0.0
         total_size = 0
 
@@ -246,19 +246,19 @@ class UserProjects(flask_restful.Resource):
             project_info["Size"] = proj_size
 
             if usage:
-                proj_gbhours, proj_cost = DBConnector().project_usage(p)
-                total_gbhours_db += proj_gbhours
+                proj_bhours, proj_cost = DBConnector().project_usage(p)
+                total_bhours_db += proj_bhours
                 total_cost_db += proj_cost
-                # undo calculation of GBhours and return ByteHours
-                project_info.update({"Usage": proj_gbhours * 10e9, "Cost": proj_cost})
+                # return ByteHours
+                project_info.update({"Usage": proj_bhours, "Cost": proj_cost})
 
             all_projects.append(project_info)
 
         return_info = {
             "project_info": all_projects,
             "total_usage": {
-                # undo calculation of GBhours and return ByteHours
-                "usage": total_gbhours_db * 10e9,
+                # return ByteHours
+                "usage": total_bhours_db,
                 "cost": total_cost_db,
             },
             "total_size": total_size,


### PR DESCRIPTION
Adresses #671:

- This PR fixes the faulty GBhours calculation. The _version size_ need to be multiplied with the _file hours_ and not divided by them. 
- Also changes to using Bytehours throughout the endpoint code and skips rounding early to avoid floating point errors. 