### PR TITLE
Issue#654: Make sure time_deleted is set on all versions of a file

### DIFF
--- a/dds_web/api/db_connector.py
+++ b/dds_web/api/db_connector.py
@@ -156,7 +156,20 @@ class DBConnector:
             if num_deleted == 0:
                 raise EmptyProjectException(project=self.project.public_id)
 
-            return True
+        try:
+            # Update all versions associated with project
+            models.Version.query.filter(
+                sqlalchemy.and_(
+                    models.Version.project_id == self.project.id,
+                    models.Version.time_deleted.is_(None),
+                )
+            ).update({"time_deleted": dds_web.utils.current_time()})
+            db.session.commit()
+        except sqlalchemy.exc.SQLAlchemyError as err:
+            db.session.rollback()
+            raise DatabaseError(message=str(err))
+
+        return True
 
     def delete_folder(self, folder):
         """Delete all items in folder"""


### PR DESCRIPTION
Ensure that `api.db.connector.delete_all()` also updates _time.deleted_ column in the versions table of the database. The should close issue #654.

New PR to supersede PR [#678](https://github.com/ScilifelabDataCentre/dds_web/pull/678) that became a bit cluttered. 