### PR TITLE
Encrypted token and authentication tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ docker-compose -f docker-compose.yml -f tests/docker-compose-test.yml up --build
 ```
 This will create a test database in the mariadb container called `DeliverySystemTest` which will be populated before a test and emptied after a test has finished.
 
-Its possible to supply arguments to pytest via the environment variable `$DDS_PYTEST_ARGS`.
+It's possible to supply arguments to pytest via the environment variable `$DDS_PYTEST_ARGS`.
 For example to only run the `test_x` inside the file `tests/test_y.py` you would set this variable as follows: `export DDS_PYTEST_ARGS=tests/test_y.py::test_x`.
 
 ## Production

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ docker-compose -f docker-compose.yml -f tests/docker-compose-test.yml up --build
 ```
 This will create a test database in the mariadb container called `DeliverySystemTest` which will be populated before a test and emptied after a test has finished.
 
+Its possible to supply arguments to pytest via the environment variable `$DDS_PYTEST_ARGS`.
+For example to only run the `test_x` inside the file `tests/test_y.py` you would set this variable as follows: `export DDS_PYTEST_ARGS=tests/test_y.py::test_x`.
+
 ## Production
 
 When running in production, you will likely want to manually build and run the two containers.

--- a/dds_web/api/__init__.py
+++ b/dds_web/api/__init__.py
@@ -34,6 +34,7 @@ api.add_resource(user.NewUser, "/user/new", endpoint="new_user")
 
 # Login/access ###################################################################### Login/access #
 api.add_resource(user.Token, "/user/token", endpoint="token")
+api.add_resource(user.EncryptedToken, "/user/encrypted_token", endpoint="encrypted_token")
 
 # S3 ########################################################################################## S3 #
 api.add_resource(s3.S3Info, "/s3/proj", endpoint="proj_s3_info")

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -362,6 +362,20 @@ class Token(flask_restful.Resource):
         return flask.jsonify({"token": jwt_token(username=auth.current_user().username)})
 
 
+class EncryptedToken(flask_restful.Resource):
+    """Generates encrypted token for the user."""
+
+    @auth.login_required
+    def get(self):
+        return flask.jsonify(
+            {
+                "token": encrypted_jwt_token(
+                    username=auth.current_user().username, sensitive_content=None
+                )
+            }
+        )
+
+
 class ShowUsage(flask_restful.Resource):
     """Calculate and display the amount of GB hours and the total cost."""
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -81,6 +81,7 @@ class DDSEndpoint:
 
     # Authentication - user and project
     TOKEN = BASE_ENDPOINT + "/user/token"
+    ENCRYPTED_TOKEN = BASE_ENDPOINT + "/user/encrypted_token"
 
     # S3Connector keys
     S3KEYS = BASE_ENDPOINT + "/s3/proj"

--- a/tests/docker-compose-test.yml
+++ b/tests/docker-compose-test.yml
@@ -5,9 +5,10 @@ services:
   backend:
     environment:
       - MYSQL_ROOT_PASSWORD=${DDS_MYSQL_ROOT_PASS}
+      - DDS_PYTEST_ARGS=${DDS_PYTEST_ARGS}
     build:
       dockerfile: Dockerfiles/backend.Dockerfile
       context: ./
       target: test
-    command: bash -c "pytest"
+    command: bash -c "pytest $DDS_PYTEST_ARGS"
     restart: "no"

--- a/tests/test_basic_api.py
+++ b/tests/test_basic_api.py
@@ -3,12 +3,15 @@
 # Standard library
 import flask
 import http
+import datetime
 
 # Installed
 from jwcrypto import jwk, jws
 
 # Own
 import tests
+import dds_web
+from dds_web.api.user import encrypted_jwt_token, jwt_token
 
 # TESTS #################################################################################### TESTS #
 
@@ -95,3 +98,156 @@ def test_auth_correctauth_check_statuscode_200_correct_info(client):
     assert (
         payload.get("sub") == tests.UserAuth(tests.USER_CREDENTIALS["researchuser"]).as_tuple()[0]
     )
+
+
+def test_auth_incorrect_token_without_periods(client):
+    """Test that a malformatted token returns unauthorized"""
+
+    # Fetch the project public key as an example
+    response = client.get(
+        tests.DDSEndpoint.PROJ_PUBLIC,
+        query_string={"project": "public_project_id"},
+        headers={"Authorization": "Bearer " + "madeuptoken"},
+    )
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED
+    response_json = response.json
+    assert response_json.get("message")
+    assert "Invalid token" == response_json.get("message")
+
+
+def test_auth_incorrect_token_with_periods(client):
+    """Test that a made up token returns unauthorized"""
+
+    # Fetch the project public key as an example
+    response = client.get(
+        tests.DDSEndpoint.PROJ_PUBLIC,
+        query_string={"project": "public_project_id"},
+        headers={"Authorization": "Bearer made.up.token"},
+    )
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED
+    response_json = response.json
+    assert response_json.get("message")
+    assert "Invalid token" == response_json.get("message")
+
+
+def test_auth_expired_signed_token(client):
+    """Test that an signed expired token returns unauthorized"""
+
+    token = dds_web.api.user.jwt_token("researchuser", expires_in=datetime.timedelta(hours=-2))
+    # Fetch the project public key as an example
+    response = client.get(
+        tests.DDSEndpoint.PROJ_PUBLIC,
+        query_string={"project": "public_project_id"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED
+    response_json = response.json
+    assert response_json.get("message")
+    assert "Expired token" == response_json.get("message")
+
+
+def test_auth_token_wrong_secret_key_signed_token(client):
+    """Test that an encrypted token signed with the wrong key returns unauthorized"""
+
+    old_secret = flask.current_app.config.get("SECRET_KEY")
+    flask.current_app.config["SECRET_KEY"] = "XX" * 16
+    token = dds_web.api.user.jwt_token("researchuser", expires_in=datetime.timedelta(hours=-2))
+    # reset secret key
+    flask.current_app.config["SECRET_KEY"] = old_secret
+
+    # Fetch the project public key as an example
+    response = client.get(
+        tests.DDSEndpoint.PROJ_PUBLIC,
+        query_string={"project": "public_project_id"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED
+    response_json = response.json
+    assert response_json.get("message")
+    assert "Invalid token" == response_json.get("message")
+
+
+def test_auth_with_token(client):
+    """Test that token can be used for authentication"""
+    response = client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS["researchuser"]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    response_json = response.json
+    assert response_json.get("token")
+
+    # Fetch the project public key as an example
+    response = client.get(
+        tests.DDSEndpoint.PROJ_PUBLIC,
+        query_string={"project": "public_project_id"},
+        headers={"Authorization": "Bearer " + response_json.get("token")},
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    response_json = response.json
+    assert response_json.get("public")
+
+
+# ENCRYPTED TOKEN ################################################################ ENCRYPTED TOKEN #
+
+
+def test_auth_expired_encrypted_token(client):
+    """Test that an encrypted expired token returns unauthorized"""
+
+    token = dds_web.api.user.encrypted_jwt_token(
+        "researchuser", None, expires_in=datetime.timedelta(hours=-2)
+    )
+    # Fetch the project public key as an example
+    response = client.get(
+        tests.DDSEndpoint.PROJ_PUBLIC,
+        query_string={"project": "public_project_id"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED
+    response_json = response.json
+    assert response_json.get("message")
+    assert "Expired token" == response_json.get("message")
+
+
+def test_auth_token_wrong_secret_key_encrypted_token(client):
+    """Test that an encrypted token signed with the wrong key returns unauthorized"""
+
+    old_secret = flask.current_app.config.get("SECRET_KEY")
+    flask.current_app.config["SECRET_KEY"] = "XX" * 16
+    token = dds_web.api.user.encrypted_jwt_token(
+        "researchuser", None, expires_in=datetime.timedelta(hours=-2)
+    )
+    # reset secret key
+    flask.current_app.config["SECRET_KEY"] = old_secret
+
+    # Fetch the project public key as an example
+    response = client.get(
+        tests.DDSEndpoint.PROJ_PUBLIC,
+        query_string={"project": "public_project_id"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED
+    response_json = response.json
+    assert response_json.get("message")
+    assert "Invalid token" == response_json.get("message")
+
+
+def test_auth_with_encrypted_token(client):
+    """Test that token can be used for authentication"""
+    response = client.get(
+        tests.DDSEndpoint.ENCRYPTED_TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS["researchuser"]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    response_json = response.json
+    assert response_json.get("token")
+
+    # Fetch the project public key as an example
+    response = client.get(
+        tests.DDSEndpoint.PROJ_PUBLIC,
+        query_string={"project": "public_project_id"},
+        headers={"Authorization": "Bearer " + response_json.get("token")},
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    response_json = response.json
+    assert response_json.get("public")


### PR DESCRIPTION
- Enabled the encrypted token endpoint (all code needed was already in place)
- Added tests for token authentication:
  -  malformed tokens
  - expired tokens
  - tokens using the wrong secret key
- The same for encrypted tokens
- Added error handling for the verify_token method to catch errors raised by tests above
- As a bonus, added possibility to supply arguments to pytest to enable running only a few tests which is really useful during development.

This PR should fix #695.