### PR TITLE
Fix foreign key constraints

### DIFF
--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -35,7 +35,9 @@ class ProjectUsers(db.Model):
     __tablename__ = "projectusers"
 
     # Primary keys / Foreign keys
-    project_id = db.Column(db.Integer, db.ForeignKey("projects.id"), primary_key=True)
+    project_id = db.Column(
+        db.Integer, db.ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
+    )
     user_id = db.Column(
         db.String(50), db.ForeignKey("researchusers.username", ondelete="CASCADE"), primary_key=True
     )
@@ -44,8 +46,10 @@ class ProjectUsers(db.Model):
     owner = db.Column(db.Boolean, nullable=False, default=False, unique=False)
 
     # Relationships - many to many
-    project = db.relationship("Project", backref="researchusers")
-    researchuser = db.relationship("ResearchUser", backref="project_associations")
+    # project = db.relationship("Project", backref="researchusers")
+    project = db.relationship("Project", back_populates="researchusers")
+    # researchuser = db.relationship("ResearchUser", backref="project_associations")
+    researchuser = db.relationship("ResearchUser", back_populates="project_associations")
 
 
 class ProjectStatuses(db.Model):
@@ -54,9 +58,15 @@ class ProjectStatuses(db.Model):
     __tablename__ = "projectstatuses"
 
     # Primary keys / Foreign keys
-    project_id = db.Column(db.Integer, db.ForeignKey("projects.id"), primary_key=True)
+    project_id = db.Column(
+        db.Integer, db.ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
+    )
     status = db.Column(db.String(50), unique=False, nullable=False, primary_key=True)
+
     date_created = db.Column(db.DateTime(), nullable=False, primary_key=True)
+
+    # Relationships
+    project = db.relationship("Project", back_populates="project_statuses")
 
 
 ####################################################################################################
@@ -147,8 +157,13 @@ class Project(db.Model):
     expired_files = db.relationship("ExpiredFile", backref="assigned_project")
     # One project can have many file versions
     file_versions = db.relationship("Version", backref="responsible_project")
+
     # One project can have a history of statuses
-    project_statuses = db.relationship("ProjectStatuses", backref="project")
+    # project_statuses = db.relationship("ProjectStatuses", backref="project")
+    project_statuses = db.relationship("ProjectStatuses", back_populates="project")
+
+    # Project users
+    researchusers = db.relationship("ProjectUsers", back_populates="project")
 
     @property
     def current_status(self):
@@ -333,6 +348,9 @@ class ResearchUser(User):
     username = db.Column(
         db.String(50), db.ForeignKey("users.username", ondelete="CASCADE"), primary_key=True
     )
+
+    # Relationships
+    project_associations = db.relationship("ProjectUsers", back_populates="researchuser")
 
     @property
     def role(self):

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -116,7 +116,9 @@ class Project(db.Model):
     unit_id = db.Column(db.Integer, db.ForeignKey("units.id"), nullable=False)
 
     # One project can be created by one user
-    created_by = db.Column(db.String(50), db.ForeignKey("users.username"), nullable=False)
+    created_by = db.Column(
+        db.String(50), db.ForeignKey("users.username", ondelete="SET NULL"), nullable=True
+    )
 
     # Columns
     public_id = db.Column(db.String(255), unique=True, nullable=False)
@@ -137,6 +139,8 @@ class Project(db.Model):
     is_sensitive = db.Column(db.Boolean, unique=False, nullable=False, default=False)
 
     # Relationships
+    creator = db.relationship("User", back_populates="created_projects")
+
     # One project can have many files
     files = db.relationship("File", backref="project")
     # One project can have many expired files
@@ -212,8 +216,10 @@ class User(flask_login.UserMixin, db.Model):
     emails = db.relationship(
         "Email", back_populates="user", cascade="all, delete", passive_deletes=True
     )
+
     # One user can create many projects
-    created_projects = db.relationship("Project", backref="user", cascade="all, delete-orphan")
+    # created_projects = db.relationship("Project", backref="user", cascade="all, delete-orphan")
+    created_projects = db.relationship("Project", back_populates="creator")
 
     __mapper_args__ = {"polymorphic_on": type}  # No polymorphic identity --> no create only user
 
@@ -348,7 +354,9 @@ class UnitUser(User):
     __mapper_args__ = {"polymorphic_identity": "unituser"}
 
     # Primary key and foreign key pointing to users
-    username = db.Column(db.String(50), db.ForeignKey("users.username"), primary_key=True)
+    username = db.Column(
+        db.String(50), db.ForeignKey("users.username", ondelete="CASCADE"), primary_key=True
+    )
 
     # Foreign key and backref with infrastructure
     unit_id = db.Column(db.Integer, db.ForeignKey("units.id"), nullable=False)

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -36,7 +36,9 @@ class ProjectUsers(db.Model):
 
     # Primary keys / Foreign keys
     project_id = db.Column(db.Integer, db.ForeignKey("projects.id"), primary_key=True)
-    user_id = db.Column(db.String(50), db.ForeignKey("researchusers.username"), primary_key=True)
+    user_id = db.Column(
+        db.String(50), db.ForeignKey("researchusers.username", ondelete="CASCADE"), primary_key=True
+    )
 
     # Columns
     owner = db.Column(db.Boolean, nullable=False, default=False, unique=False)
@@ -202,7 +204,10 @@ class User(flask_login.UserMixin, db.Model):
     # One user can have many identifiers
     identifiers = db.relationship("Identifier", backref="user", cascade="all, delete-orphan")
     # One user can have many email addresses
-    emails = db.relationship("Email", backref="user", lazy="dynamic", cascade="all, delete-orphan")
+    # emails = db.relationship("Email", backref="user", lazy="dynamic", cascade="all, delete-orphan")
+    emails = db.relationship(
+        "Email", back_populates="user", cascade="all, delete", passive_deletes=True
+    )
     # One user can create many projects
     created_projects = db.relationship("Project", backref="user", cascade="all, delete-orphan")
 
@@ -315,7 +320,9 @@ class ResearchUser(User):
     __mapper_args__ = {"polymorphic_identity": "researchuser"}
 
     # primary key and foreign key pointing to users
-    username = db.Column(db.String(50), db.ForeignKey("users.username"), primary_key=True)
+    username = db.Column(
+        db.String(50), db.ForeignKey("users.username", ondelete="CASCADE"), primary_key=True
+    )
 
     @property
     def role(self):
@@ -418,10 +425,15 @@ class Email(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
 
     # Foreign key: One user can have multiple email addresses.
-    user_id = db.Column(db.String(50), db.ForeignKey("users.username"))
+    user_id = db.Column(
+        db.String(50), db.ForeignKey("users.username", ondelete="CASCADE"), nullable=False
+    )
 
     email = db.Column(db.String(254), unique=True, nullable=False)
     primary = db.Column(db.Boolean, unique=False, nullable=False, default=False)
+
+    # Relationships
+    user = db.relationship("User", back_populates="emails")
 
     def __repr__(self):
         """Called by print, creates representation of object"""

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -129,9 +129,7 @@ class Project(db.Model):
     unit_id = db.Column(db.Integer, db.ForeignKey("units.id", ondelete="CASCADE"), nullable=False)
 
     # One project can be created by one user
-    created_by = db.Column(
-        db.String(50), db.ForeignKey("users.username", ondelete="SET NULL"), nullable=True
-    )
+    created_by = db.Column(db.String(50), db.ForeignKey("users.username", ondelete="SET NULL"))
 
     # Columns
     public_id = db.Column(db.String(255), unique=True, nullable=False)
@@ -155,9 +153,13 @@ class Project(db.Model):
     creator = db.relationship("User", back_populates="created_projects")
 
     # One project can have many files
-    files = db.relationship("File", backref="project")
+    # files = db.relationship("File", backref="project")
+    files = db.relationship("File", back_populates="project")
+
     # One project can have many expired files
-    expired_files = db.relationship("ExpiredFile", backref="assigned_project")
+    # expired_files = db.relationship("ExpiredFile", backref="assigned_project")
+    expired_files = db.relationship("ExpiredFile", back_populates="assigned_project")
+
     # One project can have many file versions
     file_versions = db.relationship("Version", backref="responsible_project")
 
@@ -522,7 +524,7 @@ class File(db.Model):
     id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
 
     # Foreign keys: One project can have many files
-    project_id = db.Column(db.Integer, db.ForeignKey("projects.id"), index=True)
+    project_id = db.Column(db.Integer, db.ForeignKey("projects.id", ondelete="CASCADE"), index=True)
 
     name = db.Column(db.Text, unique=False, nullable=False)
     name_in_bucket = db.Column(db.Text, unique=False, nullable=False)
@@ -543,6 +545,7 @@ class File(db.Model):
     )
 
     # Relationships
+    project = db.relationship("Project", back_populates="files")
     versions = db.relationship("Version", backref="file")
 
     def __repr__(self):
@@ -580,7 +583,10 @@ class ExpiredFile(db.Model):
 
     # Foreign keys
     # One project can have many files
-    project_id = db.Column(db.Integer, db.ForeignKey("projects.id"))
+    project_id = db.Column(db.Integer, db.ForeignKey("projects.id", ondelete="CASCADE"))
+
+    # Relationships
+    assigned_project = db.relationship("Project", back_populates="expired_files")
 
     def __repr__(self):
         """Called by print, creates representation of object"""

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -100,11 +100,14 @@ class Unit(db.Model):
 
     # Relationships
     # One unit can have many users
-    users = db.relationship("UnitUser", backref="unit")
+    # users = db.relationship("UnitUser", backref="unit")
+    users = db.relationship("UnitUser", back_populates="unit")
     # One unit can have many projects
-    projects = db.relationship("Project", backref="responsible_unit")
+    # projects = db.relationship("Project", backref="responsible_unit")
+    projects = db.relationship("Project", back_populates="responsible_unit")
     # One unit can have many invites
-    invites = db.relationship("Invite", backref="unit")
+    # invites = db.relationship("Invite", backref="unit")
+    invites = db.relationship("Invite", back_populates="unit")
 
     def __repr__(self):
         """Called by print, creates representation of object"""
@@ -123,7 +126,7 @@ class Project(db.Model):
 
     # Foreign keys
     # One project is associated to one unit. One unit can have many projects.
-    unit_id = db.Column(db.Integer, db.ForeignKey("units.id"), nullable=False)
+    unit_id = db.Column(db.Integer, db.ForeignKey("units.id", ondelete="CASCADE"), nullable=False)
 
     # One project can be created by one user
     created_by = db.Column(
@@ -164,6 +167,9 @@ class Project(db.Model):
 
     # Project users
     researchusers = db.relationship("ProjectUsers", back_populates="project")
+
+    # Unit
+    responsible_unit = db.relationship("Unit", back_populates="projects")
 
     @property
     def current_status(self):
@@ -377,9 +383,12 @@ class UnitUser(User):
     )
 
     # Foreign key and backref with infrastructure
-    unit_id = db.Column(db.Integer, db.ForeignKey("units.id"), nullable=False)
+    unit_id = db.Column(db.Integer, db.ForeignKey("units.id", ondelete="CASCADE"), nullable=False)
 
     is_admin = db.Column(db.Boolean, nullable=False, default=False)
+
+    # Relationships
+    unit = db.relationship("Unit", back_populates="users")
 
     @property
     def role(self):
@@ -487,11 +496,14 @@ class Invite(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
 
     # Foreign key
-    unit_id = db.Column(db.Integer, db.ForeignKey("units.id"))
+    unit_id = db.Column(db.Integer, db.ForeignKey("units.id", ondelete="CASCADE"))
 
     # Columns
     email = db.Column(db.String(254), unique=True, nullable=False)
     role = db.Column(db.String(20), unique=False, nullable=False)
+
+    # Relationships
+    unit = db.relationship("Unit", back_populates="invites")
 
     def __repr__(self):
         """Called by print, creates representation of object"""

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -101,13 +101,13 @@ class Unit(db.Model):
     # Relationships
     # One unit can have many users
     # users = db.relationship("UnitUser", backref="unit")
-    users = db.relationship("UnitUser", back_populates="unit")
+    users = db.relationship("UnitUser", back_populates="unit", passive_deletes=True)
     # One unit can have many projects
     # projects = db.relationship("Project", backref="responsible_unit")
-    projects = db.relationship("Project", back_populates="responsible_unit")
+    projects = db.relationship("Project", back_populates="responsible_unit", passive_deletes=True)
     # One unit can have many invites
     # invites = db.relationship("Invite", backref="unit")
-    invites = db.relationship("Invite", back_populates="unit")
+    invites = db.relationship("Invite", back_populates="unit", passive_deletes=True)
 
     def __repr__(self):
         """Called by print, creates representation of object"""
@@ -154,22 +154,28 @@ class Project(db.Model):
 
     # One project can have many files
     # files = db.relationship("File", backref="project")
-    files = db.relationship("File", back_populates="project")
+    files = db.relationship("File", back_populates="project", passive_deletes=True)
 
     # One project can have many expired files
     # expired_files = db.relationship("ExpiredFile", backref="assigned_project")
-    expired_files = db.relationship("ExpiredFile", back_populates="assigned_project")
+    expired_files = db.relationship(
+        "ExpiredFile", back_populates="assigned_project", passive_deletes=True
+    )
 
     # One project can have many file versions
     # file_versions = db.relationship("Version", backref="responsible_project")
-    file_versions = db.relationship("Version", back_populates="responsbile_project")
+    file_versions = db.relationship(
+        "Version", back_populates="responsbile_project", passive_deletes=True
+    )
 
     # One project can have a history of statuses
     # project_statuses = db.relationship("ProjectStatuses", backref="project")
-    project_statuses = db.relationship("ProjectStatuses", back_populates="project")
+    project_statuses = db.relationship(
+        "ProjectStatuses", back_populates="project", passive_deletes=True
+    )
 
     # Project users
-    researchusers = db.relationship("ProjectUsers", back_populates="project")
+    researchusers = db.relationship("ProjectUsers", back_populates="project", passive_deletes=True)
 
     # Unit
     responsible_unit = db.relationship("Unit", back_populates="projects")
@@ -232,15 +238,15 @@ class User(flask_login.UserMixin, db.Model):
 
     # One user can have many identifiers
     # identifiers = db.relationship("Identifier", backref="user", cascade="all, delete-orphan")
-    identifiers = db.relationship("Identifier", back_populates="user")
+    identifiers = db.relationship("Identifier", back_populates="user", passive_deletes=True)
 
     # One user can have many email addresses
     # emails = db.relationship("Email", backref="user", lazy="dynamic", cascade="all, delete-orphan")
-    emails = db.relationship("Email", back_populates="user")
+    emails = db.relationship("Email", back_populates="user", passive_deletes=True)
 
     # One user can create many projects
     # created_projects = db.relationship("Project", backref="user", cascade="all, delete-orphan")
-    created_projects = db.relationship("Project", back_populates="creator")
+    created_projects = db.relationship("Project", back_populates="creator", passive_deletes=True)
 
     __mapper_args__ = {"polymorphic_on": type}  # No polymorphic identity --> no create only user
 
@@ -356,7 +362,9 @@ class ResearchUser(User):
     )
 
     # Relationships
-    project_associations = db.relationship("ProjectUsers", back_populates="researchuser")
+    project_associations = db.relationship(
+        "ProjectUsers", back_populates="researchuser", passive_deletes=True
+    )
 
     @property
     def role(self):
@@ -544,7 +552,8 @@ class File(db.Model):
 
     # Relationships
     project = db.relationship("Project", back_populates="files")
-    versions = db.relationship("Version", backref="file")
+    # versions = db.relationship("Version", backref="file")
+    versions = db.relationship("Version", back_populates="file", passive_deletes=True)
 
     def __repr__(self):
         """Called by print, creates representation of object"""
@@ -621,6 +630,7 @@ class Version(db.Model):
 
     # Relationships
     responsbile_project = db.relationship("Project", back_populates="file_versions")
+    file = db.relationship("File", back_populates="versions")
 
     def __repr__(self):
         """Called by print, creates representation of object"""

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -202,7 +202,11 @@ class User(flask_login.UserMixin, db.Model):
     type = db.Column(db.String(20), unique=False, nullable=False)
 
     # One user can have many identifiers
-    identifiers = db.relationship("Identifier", backref="user", cascade="all, delete-orphan")
+    # identifiers = db.relationship("Identifier", backref="user", cascade="all, delete-orphan")
+    identifiers = db.relationship(
+        "Identifier", back_populates="user", cascade="all, delete", passive_deletes=True
+    )
+
     # One user can have many email addresses
     # emails = db.relationship("Email", backref="user", lazy="dynamic", cascade="all, delete-orphan")
     emails = db.relationship(
@@ -405,8 +409,13 @@ class Identifier(db.Model):
 
     # Columns
     # Foreign keys
-    username = db.Column(db.String(50), db.ForeignKey("users.username"), primary_key=True)
+    username = db.Column(
+        db.String(50), db.ForeignKey("users.username", ondelete="CASCADE"), primary_key=True
+    )
     identifier = db.Column(db.String(58), primary_key=True, unique=True, nullable=False)
+
+    # Relationships
+    user = db.relationship("User", back_populates="identifiers")
 
     def __repr__(self):
         """Called by print, creates representation of object"""

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -413,7 +413,7 @@ class UnitUser(User):
         db.String(50), db.ForeignKey("users.username", ondelete="CASCADE"), primary_key=True
     )
     # ---
-    unit_id = db.Column(db.Integer, db.ForeignKey("units.id", ondelete="CASCADE"), nullable=False)
+    unit_id = db.Column(db.Integer, db.ForeignKey("units.id", ondelete="RESTRICT"), nullable=False)
     unit = db.relationship("Unit", back_populates="users")
 
     # Additional columns

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -161,7 +161,8 @@ class Project(db.Model):
     expired_files = db.relationship("ExpiredFile", back_populates="assigned_project")
 
     # One project can have many file versions
-    file_versions = db.relationship("Version", backref="responsible_project")
+    # file_versions = db.relationship("Version", backref="responsible_project")
+    file_versions = db.relationship("Version", back_populates="responsbile_project")
 
     # One project can have a history of statuses
     # project_statuses = db.relationship("ProjectStatuses", backref="project")
@@ -219,6 +220,7 @@ class User(flask_login.UserMixin, db.Model):
     # Table setup
     __tablename__ = "users"
     __table_args__ = {"extend_existing": True}
+
     # Columns
     username = db.Column(db.String(50), primary_key=True, autoincrement=False)
     name = db.Column(db.String(255), unique=False, nullable=True)
@@ -230,15 +232,11 @@ class User(flask_login.UserMixin, db.Model):
 
     # One user can have many identifiers
     # identifiers = db.relationship("Identifier", backref="user", cascade="all, delete-orphan")
-    identifiers = db.relationship(
-        "Identifier", back_populates="user", cascade="all, delete", passive_deletes=True
-    )
+    identifiers = db.relationship("Identifier", back_populates="user")
 
     # One user can have many email addresses
     # emails = db.relationship("Email", backref="user", lazy="dynamic", cascade="all, delete-orphan")
-    emails = db.relationship(
-        "Email", back_populates="user", cascade="all, delete", passive_deletes=True
-    )
+    emails = db.relationship("Email", back_populates="user")
 
     # One user can create many projects
     # created_projects = db.relationship("Project", backref="user", cascade="all, delete-orphan")
@@ -606,7 +604,7 @@ class Version(db.Model):
 
     # Foreign key - One project can have many files
     project_id = db.Column(
-        db.Integer, db.ForeignKey("projects.id", ondelete="SET NULL"), nullable=True
+        db.Integer, db.ForeignKey("projects.id", ondelete="CASCADE"), nullable=True
     )
 
     # Foreign key - One file can have many rows in invoicing
@@ -620,6 +618,9 @@ class Version(db.Model):
     )
     time_deleted = db.Column(db.DateTime(), unique=False, nullable=True, default=None)
     time_invoiced = db.Column(db.DateTime(), unique=False, nullable=True, default=None)
+
+    # Relationships
+    responsbile_project = db.relationship("Project", back_populates="file_versions")
 
     def __repr__(self):
         """Called by print, creates representation of object"""


### PR DESCRIPTION
- I changed my mind regarding the implicit/explicit relationships: Now we have them explicitly defined and placed in connection to the corresponding foreign key for clarity.
- I also went through the different foreign key contraints and added `ondelete=CASCADE` if the child row should be deleted on parent deletion, and `ondelete=SET NULL` if the column should just be filled with NULL on deleton of the parent, e.g. for `created_by`. I had an idea of setting a value instead but I didn't find a solution for that and this works well now.