### PR TITLE
Use MAIL_DEFAULT_SENDER instead of MAIL_SENDER and MAIL_SENDER_ADDRESS

### DIFF
--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -193,7 +193,6 @@ class AddUser(flask_restful.Resource):
 
         msg = flask_mail.Message(
             subject,
-            sender=flask.current_app.config["MAIL_SENDER_ADDRESS"],
             recipients=[new_invite.email],
         )
 
@@ -380,7 +379,6 @@ class DeleteUserSelf(flask_restful.Resource):
 
         msg = flask_mail.Message(
             subject,
-            sender=flask.current_app.config["MAIL_SENDER_ADDRESS"],
             recipients=[email_str],
         )
 

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -53,7 +53,7 @@ class Config(object):
     MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD", "mailtrap_password")
     MAIL_USE_TLS = True
     MAIL_USE_SSL = False
-    MAIL_SENDER_ADDRESS = "localhost"
+    MAIL_DEFAULT_SENDER = "dds@noreply.se"
 
     TOKEN_ENDPOINT_ACCESS_LIMIT = "10/hour"
     RATELIMIT_STORAGE_URL = "memory://"  # Use in devel only! Use Redis or memcached in prod

--- a/dds_web/utils.py
+++ b/dds_web/utils.py
@@ -231,7 +231,6 @@ def send_reset_email(email_row):
     # Create and send email
     message = flask_mail.Message(
         "Password Reset Request",
-        sender=flask.current_app.config.get("MAIL_SENDER", "dds@noreply.se"),
         recipients=[email_row.email],
     )
     message.body = (


### PR DESCRIPTION
* Set `MAIL_DEFAULT_SENDER` in `config.py` instead of setting `sender` for emails
  - If an email needs a custom sender, `sender` can still be used
* Remove the duplicate settings `MAIL_SENDER` and `MAIL_SENDER_ADDRESS`