### PR TITLE
Add User activation endpoint 

### DIFF
--- a/dds_web/api/__init__.py
+++ b/dds_web/api/__init__.py
@@ -59,6 +59,7 @@ api.add_resource(user.AddUser, "/user/add", endpoint="add_user")
 api.add_resource(user.DeleteUser, "/user/delete", endpoint="delete_user")
 api.add_resource(user.DeleteUserSelf, "/user/delete_self", endpoint="delete_user_self")
 api.add_resource(user.RemoveUserAssociation, "/user/access/revoke", endpoint="revoke_from_project")
+api.add_resource(user.UserActivation, "/user/activation", endpoint="user_activation")
 
 # Invoicing ############################################################################ Invoicing #
 api.add_resource(user.InvoiceUnit, "/invoice", endpoint="invoice")

--- a/dds_web/api/errors.py
+++ b/dds_web/api/errors.py
@@ -275,7 +275,7 @@ class UserDeletionError(LoggedHTTPException):
         super().__init__(alt_message or message)
 
 
-class NoSuchUserError(Exception):
+class NoSuchUserError(LoggedHTTPException):
     """There is no such user found in the database."""
 
     def __init__(self, message="User not found."):

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -245,7 +245,7 @@ class GetPrivate(flask_restful.Resource):
         kdf = scrypt.Scrypt(
             salt=salt,
             length=32,
-            n=2 ** 14,
+            n=2**14,
             r=8,
             p=1,
             backend=backends.default_backend(),

--- a/dds_web/api/schemas/user_schemas.py
+++ b/dds_web/api/schemas/user_schemas.py
@@ -190,6 +190,7 @@ class NewUserSchema(marshmallow.Schema):
         # Create new email and append to user relationship
         new_email = models.Email(email=data.get("email"), primary=True)
         new_user.emails.append(new_email)
+        new_user.active = True
 
         db.session.add(new_user)
 

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -456,16 +456,9 @@ class UserActivation(flask_restful.Resource):
             action == "deactivate" and not user.is_active
         ):
             raise ddserr.DDSArgumentError(message=f"User is already in desired state!")
-        import pdb
-
-        pdb.set_trace()
-        if action == "reactivate":
-            activate = True
-        else:
-            activate = False
 
         try:
-            user.active = activate
+            user.active = action == "reactivate"
             db.session.commit()
         except sqlalchemy.exc.SQLAlchemyError as err:
             db.session.rollback()

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -435,6 +435,10 @@ class UserActivation(flask_restful.Resource):
     def post(self):
         user = user_schemas.UserSchema().load(flask.request.json)
         action = flask.request.json.get("action")
+        if action is None or action == "":
+            raise ddserr.DDSArgumentError(
+                message=f"Please provide an action 'deactivate' or 'reactivate' for this request."
+            )
         if user is None:
             raise ddserr.NoSuchUserError(
                 message=f"This e-mail address is not associated with a user in the DDS, make sure it is not misspelled."

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -425,6 +425,67 @@ class DeleteUserSelf(flask_restful.Resource):
         )
 
 
+class UserActivation(flask_restful.Resource):
+    """Endpoint to reactivate/deactivate users in the system
+
+    Unit admins can reactivate/deactivate unitusers. Super admins can reactivate/deactivate any user."""
+
+    @auth.login_required(role=["Super Admin", "Unit Admin"])
+    @logging_bind_request
+    def post(self):
+
+        user = user_schemas.UserSchema().load(flask.request.json)
+        action = flask.request.json.get("action")
+        if user is None:
+            raise ddserr.NoSuchUserError(
+                message=f"This e-mail address is not associated with a user in the DDS, make sure it is not misspelled."
+            )
+        user_email_str = user.primary_email
+        current_user = auth.current_user()
+
+        if current_user.role == "Unit Admin":
+            if user.role not in ["Unit Admin", "Unit Personnel"] or current_user.unit != user.unit:
+                raise ddserr.AccessDeniedError(
+                    message=f"You are not allowed to {action} this user. As a unit admin, you're only allowed to {action} users in your unit."
+                )
+
+        if current_user == user:
+            raise ddserr.AccessDeniedError(message=f"You cannot {action} your own account!")
+
+        if (action == "reactivate" and user.is_active) or (
+            action == "deactivate" and not user.is_active
+        ):
+            raise ddserr.DDSArgumentError(message=f"User is already in desired state!")
+
+        if action == "reactivate":
+            activate = True
+        else:
+            activate = False
+
+        try:
+            user.active = activate
+            db.session.commit()
+        except sqlalchemy.exc.SQLAlchemyError as err:
+            db.session.rollback()
+            raise DatabaseError(message=str(err))
+        msg = f"The user account {user.username} ({user_email_str}, {user.role})  has been {action}d successfully been by {current_user.name} ({current_user.role})."
+        flask.current_app.logger.info(msg)
+
+        with structlog.threadlocal.bound_threadlocal(
+            who={"user": user.username, "role": user.role},
+            by_whom={"user": current_user.username, "role": current_user.role},
+        ):
+            action_logger.info(self.__class__)
+
+        return flask.make_response(
+            flask.jsonify(
+                {
+                    "message": f"You successfully {action}d the account {user.username} ({user_email_str}, {user.role})!"
+                }
+            )
+        )
+
+
 class DeleteUser(flask_restful.Resource):
     """Endpoint to remove users from the system
 

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -456,7 +456,9 @@ class UserActivation(flask_restful.Resource):
             action == "deactivate" and not user.is_active
         ):
             raise ddserr.DDSArgumentError(message=f"User is already in desired state!")
+        import pdb
 
+        pdb.set_trace()
         if action == "reactivate":
             activate = True
         else:

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -433,7 +433,6 @@ class UserActivation(flask_restful.Resource):
     @auth.login_required(role=["Super Admin", "Unit Admin"])
     @logging_bind_request
     def post(self):
-
         user = user_schemas.UserSchema().load(flask.request.json)
         action = flask.request.json.get("action")
         if user is None:
@@ -457,6 +456,7 @@ class UserActivation(flask_restful.Resource):
         ):
             raise ddserr.DDSArgumentError(message=f"User is already in desired state!")
 
+        # TODO: Check if user has lost access to any projects and if so, grant access again.
         try:
             user.active = action == "reactivate"
             db.session.commit()

--- a/dds_web/crypt/key_gen.py
+++ b/dds_web/crypt/key_gen.py
@@ -55,7 +55,7 @@ class ProjectKeys:
         scrpyt_salt = scrypt.Scrypt(
             salt=self._salt,
             length=32,
-            n=2 ** 14,
+            n=2**14,
             r=8,
             p=1,
             backend=backends.default_backend(),

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -282,6 +282,7 @@ class User(flask_login.UserMixin, db.Model):
     _password_hash = db.Column(db.String(98), unique=False, nullable=False)
     _otp_secret = db.Column(db.String(32))
     has_2fa = db.Column(db.Boolean)
+    active = db.Column(db.Boolean)
 
     # Inheritance related, set automatically
     type = db.Column(db.String(20), unique=False, nullable=False)
@@ -411,6 +412,10 @@ class User(flask_login.UserMixin, db.Model):
         """Get users primary email."""
         prims = [x.email for x in self.emails if x.primary]
         return prims[0] if len(prims) > 0 else None
+
+    @property
+    def is_active(self):
+        return self.active
 
     def __repr__(self):
         """Called by print, creates representation of object"""

--- a/dds_web/development/db_init.py
+++ b/dds_web/development/db_init.py
@@ -77,6 +77,8 @@ def fill_db():
     # Connect project to association row. = (not append) due to one project per ass. row
     project_1_user_1_association.project = project_1
 
+    researchuser_1.active = True
+
     email_researchuser_2 = models.Email(email="researchuser2@mailtrap.io", primary=True)
     # Create second research user
     researchuser_2 = models.ResearchUser(
@@ -91,6 +93,8 @@ def fill_db():
     project_1_user_2_association.researchuser = researchuser_2
     # Connect project to association row. = (not append) due to one project per ass. row
     project_1_user_2_association.project = project_1
+
+    researchuser_2.active = True
 
     # Create first unit user
     unituser_1 = models.UnitUser(
@@ -112,6 +116,8 @@ def fill_db():
     email_unituser_1.user = unituser_1
     email_unituser_1b.user = unituser_1
     email_unituser_2.user = unituser_2
+    unituser_1.active = True
+    unituser_2.active = True
 
     # Add created project
     unituser_1.created_projects.append(project_1)

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -83,7 +83,9 @@ def verify_token(token):
         username = data.get("sub")
         if username:
             user = models.User.query.get(username)
-        return user or None
+        if user and user.is_active:
+            return user
+        return None
     raise AuthenticationError(message="Expired token")
 
 
@@ -124,6 +126,6 @@ def verify_token_signature(token):
 def verify_password(username, password):
     """Verify that user exists and that password is correct."""
     user = models.User.query.get(username)
-    if user and user.verify_password(input_password=password):
+    if user and user.is_active and user.verify_password(input_password=password):
         return user
     return None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -121,6 +121,9 @@ class DDSEndpoint:
     # Remove user from project
     REMOVE_USER_FROM_PROJ = BASE_ENDPOINT + "/user/access/revoke"
 
+    # User activation
+    USER_ACTIVATION = BASE_ENDPOINT + "/user/activation"
+
     # S3Connector keys
     S3KEYS = BASE_ENDPOINT + "/s3/proj"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -330,6 +330,9 @@ def add_data_to_db():
 
     units[1].users.extend([users[8], users[9]])
 
+    for user in users:
+        user.active = True
+
     return units, users
 
 

--- a/tests/test_user_activation.py
+++ b/tests/test_user_activation.py
@@ -1,0 +1,234 @@
+# Standard libraries
+import http
+
+# Installed
+import json
+
+# Own
+import tests
+
+user = {"email": "researchuser2@mailtrap.io", "username": "researchuser2", "role": "Researcher"}
+unituser = {"email": "unituser1@mailtrap.io", "username": "unituser", "role": "Unit Personnel"}
+
+
+def test_deactivate_self_as_superadmin(module_client):
+    """Deactivate self as superadmin"""
+    response = module_client.post(
+        tests.DDSEndpoint.USER_ACTIVATION,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(module_client),
+        data=json.dumps({"email": "superadmin@mailtrap.io", "action": "deactivate"}),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN
+    assert f"You cannot deactivate your own account!" in response.json["message"]
+
+
+def test_deactivate_nouser_as_superadmin(module_client):
+    """Deactivate nonexistent user as superadmin"""
+    response = module_client.post(
+        tests.DDSEndpoint.USER_ACTIVATION,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(module_client),
+        data=json.dumps({"email": "nossuchemail@mailtrap.io", "action": "deactivate"}),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.BAD_REQUEST
+    assert (
+        f"This e-mail address is not associated with a user in the DDS, make sure it is not misspelled."
+        in response.json["message"]
+    )
+
+
+def test_deactivate_user_as_superadmin(module_client):
+    """Deactivate researchuser as super admin"""
+    # Try to get token as user that is to be deactivated
+    response = module_client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS[user["username"]]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    # Deactivate user
+    response = module_client.post(
+        tests.DDSEndpoint.USER_ACTIVATION,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(module_client),
+        data=json.dumps({**user, "action": "deactivate"}),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    assert (
+        f"You successfully deactivated the account {user['username']} ({user['email']}, {user['role']})!"
+        in response.json["message"]
+    )
+
+    # Try to get token after deactivation
+    response = module_client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS[user["username"]]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED
+
+
+def test_deactivate_deactivated_user_as_superadmin(module_client):
+    """Deactivate deactivated researchuser as super admin"""
+    # Deactivate user again
+    response = module_client.post(
+        tests.DDSEndpoint.USER_ACTIVATION,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(module_client),
+        data=json.dumps({**user, "action": "deactivate"}),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.BAD_REQUEST
+    assert "User is already in desired state!" in response.json["message"]
+
+
+def test_reactivate_user_as_superadmin(module_client):
+    """Reactivate researchuser as super admin"""
+    # Try to get token as user that is to be deactivated
+    response = module_client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS[user["username"]]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED
+
+    # Reactivate user
+    response = module_client.post(
+        tests.DDSEndpoint.USER_ACTIVATION,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(module_client),
+        data=json.dumps({**user, "action": "reactivate"}),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    assert (
+        f"You successfully reactivated the account {user['username']} ({user['email']}, {user['role']})!"
+        in response.json["message"]
+    )
+
+    # Try to get token after reactivation
+    response = module_client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS[user["username"]]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+
+def test_deactivate_user_as_unitadmin(module_client):
+    """Deactivate researchuser as unit admin"""
+    # Try to get token as user that is to be deactivated
+    response = module_client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS[user["username"]]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    # Deactivate user
+    response = module_client.post(
+        tests.DDSEndpoint.USER_ACTIVATION,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        data=json.dumps({**user, "action": "deactivate"}),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN
+    assert (
+        "You are not allowed to deactivate this user. As a unit admin, you're only allowed to deactivate users in your unit."
+        in response.json["message"]
+    )
+
+
+def test_deactivate_unituser_as_unitadmin(module_client):
+    """Deactivate unit user as unit admin"""
+    # Try to get token as user that is to be deactivated
+    response = module_client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS[unituser["username"]]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    # Deactivate user
+    response = module_client.post(
+        tests.DDSEndpoint.USER_ACTIVATION,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        data=json.dumps({**unituser, "action": "deactivate"}),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    assert (
+        f"You successfully deactivated the account {unituser['username']} ({unituser['email']}, {unituser['role']})!"
+        in response.json["message"]
+    )
+
+    # Try to get token after deactivation
+    response = module_client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS[unituser["username"]]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED
+
+
+def test_reactivate_unituser_as_unitadmin(module_client):
+    """Reactivate unituser as unit admin"""
+    # Try to get token as user that is to be deactivated
+    response = module_client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS[unituser["username"]]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.UNAUTHORIZED
+
+    # Reactivate user
+    response = module_client.post(
+        tests.DDSEndpoint.USER_ACTIVATION,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        data=json.dumps({**unituser, "action": "reactivate"}),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    assert (
+        f"You successfully reactivated the account {unituser['username']} ({unituser['email']}, {unituser['role']})!"
+        in response.json["message"]
+    )
+
+    # Try to get token after reactivation
+    response = module_client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS[unituser["username"]]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+
+def test_deactivate_user_as_unituser(module_client):
+    """Deactivate researchuser as unit user"""
+    # Try to get token as user that is to be deactivated
+    response = module_client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS[user["username"]]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    # Deactivate user
+    response = module_client.post(
+        tests.DDSEndpoint.USER_ACTIVATION,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(module_client),
+        data=json.dumps({**user, "action": "deactivate"}),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN
+    assert "Insufficient credentials" in response.json["message"]
+
+
+def test_deactivate_user_as_researchuser(module_client):
+    """Deactivate researchuser as researchuser"""
+    # Try to get token as user that is to be deactivated
+    response = module_client.get(
+        tests.DDSEndpoint.TOKEN,
+        auth=tests.UserAuth(tests.USER_CREDENTIALS[user["username"]]).as_tuple(),
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    # Deactivate user
+    response = module_client.post(
+        tests.DDSEndpoint.USER_ACTIVATION,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["researchuser"]).token(module_client),
+        data=json.dumps({**user, "action": "deactivate"}),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN
+    assert "Insufficient credentials" in response.json["message"]

--- a/tests/test_user_info.py
+++ b/tests/test_user_info.py
@@ -41,7 +41,7 @@ def test_get_info_unit_user(client):
     assert user_info["is_admin"]
 
 
-def test_get_info_unit_user(client):
+def test_get_info_research_user(client):
     """Get info for a research user"""
 
     response = client.get(


### PR DESCRIPTION
Addresses https://github.com/ScilifelabDataCentre/dds_web/issues/770

* Added field `active` and property `is_active` to User model
* Invited user is activated at the time of registering.
* Authentication checks whether user is active.
* Super Admin can deactivate/reactivate all user and Unit admins can do the same for unit users. All other cases are forbidden.
* Users cannot deactivate/reactivate themselves.