### PR TITLE
Embeds the tokens lifetime as isodate encoded timedelta

### DIFF
--- a/Dockerfiles/backend.Dockerfile
+++ b/Dockerfiles/backend.Dockerfile
@@ -6,7 +6,7 @@
 FROM python:latest as base
 
 # Install some necessary systems packages
-RUN apt-get update && apt-get upgrade
+RUN apt-get update && apt-get upgrade -y
 
 # Copy the content to a code folder in container
 COPY ./requirements.txt /code/requirements.txt

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -17,7 +17,6 @@ import flask
 import flask_restful
 import flask_mail
 import itsdangerous
-import isodate
 import marshmallow
 import structlog
 import sqlalchemy

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -17,6 +17,7 @@ import flask
 import flask_restful
 import flask_mail
 import itsdangerous
+import isodate
 import marshmallow
 import structlog
 import sqlalchemy
@@ -37,7 +38,6 @@ from dds_web.security.tokens import encrypted_jwt_token, update_token_with_mfa
 
 # initiate bound logger
 action_logger = structlog.getLogger("actions")
-
 
 ####################################################################################################
 # ENDPOINTS ############################################################################ ENDPOINTS #

--- a/dds_web/security/tokens.py
+++ b/dds_web/security/tokens.py
@@ -33,6 +33,7 @@ def encrypted_jwt_token(
             "alg": "A256KW",
             "enc": "A256GCM",
             "exp": (dds_web.utils.current_time() + expires_in).timestamp(),
+            "iat": (dds_web.utils.current_time()).timestamp(),
             "csg": username,
         },
         claims=__signed_jwt_token(
@@ -85,6 +86,7 @@ def __signed_jwt_token(
         header={
             "alg": "HS256",
             "exp": expiration_time.timestamp(),
+            "iat": (dds_web.utils.current_time()).timestamp(),
             "csg": username,
         },
         claims=data,

--- a/dds_web/security/tokens.py
+++ b/dds_web/security/tokens.py
@@ -32,8 +32,11 @@ def encrypted_jwt_token(
         header={
             "alg": "A256KW",
             "enc": "A256GCM",
+            # exp: This registered claim according to JWT specification identifies the time on or after which the JWT MUST NOT be accepted for processing.
             "exp": (dds_web.utils.current_time() + expires_in).timestamp(),
+            # iat: issued at value is a registered claim and identifies the time at which the token was issued.
             "iat": (dds_web.utils.current_time()).timestamp(),
+            # csg: consignee claim for transmitting the user name to which the token was issued. Is not registered according to JWT specification.
             "csg": username,
         },
         claims=__signed_jwt_token(
@@ -85,8 +88,11 @@ def __signed_jwt_token(
     token = jwt.JWT(
         header={
             "alg": "HS256",
+            # exp: This registered claim according to JWT specification identifies the time on or after which the JWT MUST NOT be accepted for processing.
             "exp": expiration_time.timestamp(),
+            # iat: issued at value is a registered claim and identifies the time at which the token was issued.
             "iat": (dds_web.utils.current_time()).timestamp(),
+            # csg: consignee claim for transmitting the user name to which the token was issued. Is not registered according to JWT specification.
             "csg": username,
         },
         claims=data,

--- a/dds_web/security/tokens.py
+++ b/dds_web/security/tokens.py
@@ -8,6 +8,7 @@ import secrets
 
 # Installed
 import flask
+import isodate
 from jwcrypto import jwk, jwt
 
 # Own modules
@@ -29,7 +30,12 @@ def encrypted_jwt_token(
     :param Dict or None additional_claims: Any additional token claims can be added. e.g., {"iss": "DDS"}
     """
     token = jwt.JWT(
-        header={"alg": "A256KW", "enc": "A256GCM"},
+        header={
+            "alg": "A256KW",
+            "enc": "A256GCM",
+            "lft": isodate.duration_isoformat(expires_in),
+            "usr": username,
+        },
         claims=__signed_jwt_token(
             username=username,
             sensitive_content=sensitive_content,
@@ -76,7 +82,11 @@ def __signed_jwt_token(
         data["sen_con"] = sensitive_content
 
     key = jwk.JWK.from_password(flask.current_app.config.get("SECRET_KEY"))
-    token = jwt.JWT(header={"alg": "HS256"}, claims=data, algs=["HS256"])
+    token = jwt.JWT(
+        header={"alg": "HS256", "lft": isodate.duration_isoformat(expires_in), "usr": username},
+        claims=data,
+        algs=["HS256"],
+    )
     token.make_signed_token(key)
     return token.serialize()
 

--- a/dds_web/security/tokens.py
+++ b/dds_web/security/tokens.py
@@ -8,7 +8,6 @@ import secrets
 
 # Installed
 import flask
-import isodate
 from jwcrypto import jwk, jwt
 
 # Own modules
@@ -33,8 +32,8 @@ def encrypted_jwt_token(
         header={
             "alg": "A256KW",
             "enc": "A256GCM",
-            "lft": isodate.duration_isoformat(expires_in),
-            "usr": username,
+            "exp": (dds_web.utils.current_time() + expires_in).timestamp(),
+            "csg": username,
         },
         claims=__signed_jwt_token(
             username=username,
@@ -83,7 +82,11 @@ def __signed_jwt_token(
 
     key = jwk.JWK.from_password(flask.current_app.config.get("SECRET_KEY"))
     token = jwt.JWT(
-        header={"alg": "HS256", "lft": isodate.duration_isoformat(expires_in), "usr": username},
+        header={
+            "alg": "HS256",
+            "exp": expiration_time.timestamp(),
+            "csg": username,
+        },
         claims=data,
         algs=["HS256"],
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==1.0.0
 idna==3.3
+isodate==0.6.1 
 itsdangerous==2.0.1
 Jinja2==3.0.3
 jmespath==0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==1.0.0
 idna==3.3
-isodate==0.6.1 
 itsdangerous==2.0.1
 Jinja2==3.0.3
 jmespath==0.10.0


### PR DESCRIPTION
This PR suggests changes to the token's header to embed some metadata about the token to be openly readable by the CLI:

- `iat`: The _issued at_ value is a registered claim according to JWT specification and identifies the time at which the JWT was issued. This claim can be used to determine the age of the JWT. Its value MUST be a number containing a NumericDate value. 
- `exp`: The _expiration time_ value is a registered claim according to JWT specification and identifies the expiration time on or after which the JWT MUST NOT be accepted for processing. The processing of the “exp” claim requires that the current date/time MUST be before the expiration date/time listed in the “exp” claim. Implementers MAY provide for some small leeway, usually no more than a few minutes, to account for clock skew. Its value MUST be a number containing a NumericDate value.
- `csg`: The _consignee_ value is **not** a registered claim according to JWT specification, but was used to include the username.