### PR TITLE
Add redis for caching

### DIFF
--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -57,5 +57,5 @@ class Config(object):
 
     TOKEN_ENDPOINT_ACCESS_LIMIT = "10/hour"
     RATELIMIT_STORAGE_URL = os.environ.get(
-        "RATELIMIT_STORAGE_URL", "memory://"
+        "RATELIMIT_STORAGE_URL", "redis://dds_redis"
     )  # Use in devel only! Use Redis or memcached in prod

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -57,5 +57,5 @@ class Config(object):
 
     TOKEN_ENDPOINT_ACCESS_LIMIT = "10/hour"
     RATELIMIT_STORAGE_URI = os.environ.get(
-        "RATELIMIT_STORAGE_URI", "redis://dds_redis"
+        "RATELIMIT_STORAGE_URI", "memory://"
     )  # Use in devel only! Use Redis or memcached in prod

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -56,6 +56,6 @@ class Config(object):
     MAIL_DEFAULT_SENDER = "dds@noreply.se"
 
     TOKEN_ENDPOINT_ACCESS_LIMIT = "10/hour"
-    RATELIMIT_STORAGE_URL = os.environ.get(
-        "RATELIMIT_STORAGE_URL", "redis://dds_redis"
+    RATELIMIT_STORAGE_URI = os.environ.get(
+        "RATELIMIT_STORAGE_URI", "redis://dds_redis"
     )  # Use in devel only! Use Redis or memcached in prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - FLASK_ENV=development
       - FLASK_APP=dds_web
       - INIT_DEV_DB=${DDS_INIT_DEV_DB}
+      # - RATELIMIT_STORAGE_URI=redis://dds_redis  # use redis for persistent limiter between code reloads
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,3 +61,7 @@ services:
       - type: bind
         source: $DDS_LOG_DIR
         target: /dds_web/logs
+
+  redis:
+    container_name: dds_redis
+    image: redis:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: "3.8"
+# for persistent endpoint limiter, uncomment RATELIMIT_STORAGE_URI and the redis entry
 
 services:
 
@@ -34,7 +35,7 @@ services:
       - FLASK_ENV=development
       - FLASK_APP=dds_web
       - INIT_DEV_DB=${DDS_INIT_DEV_DB}
-      # - RATELIMIT_STORAGE_URI=redis://dds_redis  # use redis for persistent limiter between code reloads
+      # - RATELIMIT_STORAGE_URI=redis://dds_redis
     depends_on:
       db:
         condition: service_healthy
@@ -63,6 +64,6 @@ services:
         source: $DDS_LOG_DIR
         target: /dds_web/logs
 
-  redis:
-    container_name: dds_redis
-    image: redis:latest
+#  redis:
+#    container_name: dds_redis
+#    image: redis:latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,13 +36,16 @@ limits==2.3.2
 MarkupSafe==2.0.1
 marshmallow==3.14.1
 marshmallow-sqlalchemy==0.27.0
+packaging==21.3
 pycparser==2.21
 PyMySQL==1.0.2
 PyNaCl==1.5.0
+pyparsing==3.0.7
 PyQRCode==1.2.1
 python-dateutil==2.8.2
 pytz==2021.3
 pytz-deprecation-shim==0.1.0.post0
+redis==4.1.2
 requests==2.27.1
 s3transfer==0.5.1
 six==1.16.0

--- a/tests/docker-compose-test.yml
+++ b/tests/docker-compose-test.yml
@@ -6,7 +6,6 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=${DDS_MYSQL_ROOT_PASS}
       - DDS_PYTEST_ARGS=${DDS_PYTEST_ARGS}
-      - RATELIMIT_STORAGE_URI=memory://
     build:
       dockerfile: Dockerfiles/backend.Dockerfile
       context: ./

--- a/tests/docker-compose-test.yml
+++ b/tests/docker-compose-test.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=${DDS_MYSQL_ROOT_PASS}
       - DDS_PYTEST_ARGS=${DDS_PYTEST_ARGS}
+      - RATELIMIT_STORAGE_URI=memory://
     build:
       dockerfile: Dockerfiles/backend.Dockerfile
       context: ./


### PR DESCRIPTION
Add a redis database to handle the caching for `flask-limiter`.

* Add redis to docker-compose
* Add required modules
* Using redis is not the default, and it must be activated by uncommenting the relevant lines in `docker-compose.yml` to be used for testing

Fixes #774