### PR TITLE
Add config value for argon memory cost

### DIFF
--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -59,3 +59,6 @@ class Config(object):
     RATELIMIT_STORAGE_URI = os.environ.get(
         "RATELIMIT_STORAGE_URI", "memory://"
     )  # Use in devel only! Use Redis or memcached in prod
+
+    # 512MiB; at least 4GiB (0x400000) recommended in production
+    ARGON_MEMORY_COST = os.environ.get("ARGON_MEMORY_COST", 0x80000)


### PR DESCRIPTION
Adds the config option `ARGON_MEMORY_COST` for the memory usage of Argon2.

Closes #812 