### PR TITLE
Issue 798: Add to project workflow

### DIFF
--- a/dds_web/api/schemas/user_schemas.py
+++ b/dds_web/api/schemas/user_schemas.py
@@ -5,6 +5,7 @@
 ####################################################################################################
 
 # Installed
+import flask
 import marshmallow
 import sqlalchemy
 
@@ -119,6 +120,12 @@ class NewUserSchema(marshmallow.Schema):
         required=True,
         validate=marshmallow.validate.And(marshmallow.validate.Email(), utils.email_not_taken),
     )
+    token_email = marshmallow.fields.Email(
+        required=True,
+    )
+    TKEK = marshmallow.fields.String(
+        required=True,
+    )
     name = marshmallow.fields.String(required=True, validate=marshmallow.validate.Length(max=255))
 
     class Meta:
@@ -132,10 +139,7 @@ class NewUserSchema(marshmallow.Schema):
 
         if utils.username_in_db(username=value):
             raise marshmallow.ValidationError(
-                message=(
-                    f"The username '{value}' is already taken by another user. "
-                    "Try something else."
-                )
+                message=(f"The username '{value}' is already taken by another user. ")
             )
 
     @marshmallow.validates("email")
@@ -151,11 +155,19 @@ class NewUserSchema(marshmallow.Schema):
     def verify_and_get_invite(self, data, **kwargs):
         """Verifies that the email is in the invite table and in that case saves the invite info."""
 
+        form_email = data["email"]
+        token_email = data["token_email"]  # Originates from the token and not from the form
+
+        # Avoid a simple attacker scenarios where one is submitting a different email than the invite was sent to
+        if form_email != token_email:
+            flask.current_app.logger.warning(f"Email mismatch: {form_email} != {token_email}")
+            raise ddserr.InviteError(message="Form email and token email not the same")
+
         invite = models.Invite.query.filter(
             models.Invite.email == sqlalchemy.func.binary(data.get("email"))
         ).one_or_none()
         if not invite:
-            raise ddserr.InviteError
+            raise ddserr.InviteError(message="No invite found for this email at schema validation")
 
         data["invite"] = invite
 
@@ -189,6 +201,8 @@ class NewUserSchema(marshmallow.Schema):
         new_user.active = True
 
         db.session.add(new_user)
+
+        # TODO Use the TKEK here
 
         # Delete old invite
         db.session.delete(invite)

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -74,7 +74,7 @@ class AddUser(flask_restful.Resource):
 
     @staticmethod
     @logging_bind_request
-    def invite_user(args, project):
+    def invite_user(args, project=None):
         """Invite a new user"""
 
         try:
@@ -93,7 +93,7 @@ class AddUser(flask_restful.Resource):
             raise ddserr.InviteError(message=valerr.messages)
 
         # Create URL safe token for invitation link
-        TKEK = "Bogus"
+        TKEK = "bogus"
         # TODO change to real TKEK.
 
         if project:

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -5,10 +5,11 @@
 ####################################################################################################
 
 # Standard library
+import datetime
 import os
 import smtplib
 import time
-import datetime
+import json
 
 # Installed
 import flask
@@ -89,11 +90,31 @@ class AddUser(flask_restful.Resource):
             raise ddserr.InviteError(message=valerr.messages)
 
         # Create URL safe token for invitation link
-        s = itsdangerous.URLSafeTimedSerializer(flask.current_app.config["SECRET_KEY"])
-        token = s.dumps(new_invite.email, salt="email-confirm")
+        TKEK = "bogus"
+        # TODO change to real TKEK.
+
+        sensitive_content = json.dumps({"invited_email": new_invite.email, "TKEK": TKEK})
+
+        token = encrypted_jwt_token(
+            new_invite.email,
+            sensitive_content,
+            expires_in=datetime.timedelta(
+                hours=flask.current_app.config["INVITATION_EXPIRES_IN_HOURS"]
+            ),
+        )
 
         # Create link for invitation email
         link = flask.url_for("auth_blueprint.confirm_invite", token=token, _external=True)
+
+        # Quick search gave this as the URL length limit.
+        if len(link) >= 2048:
+            flask.current_app.logger.error(
+                "Invitation link was not possible to create due to length."
+            )
+            return {
+                "message": "Invite failed due to server error",
+                "status": http.HTTPStatus.INTERNAL_SERVER_ERROR,
+            }
 
         # Compose and send email
         AddUser.compose_and_send_email_to_user(new_invite, "invite", link=link)

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -60,5 +60,7 @@ class Config(object):
         "RATELIMIT_STORAGE_URI", "memory://"
     )  # Use in devel only! Use Redis or memcached in prod
 
+    INVITATION_EXPIRES_IN_HOURS = 7 * 24
+
     # 512MiB; at least 4GiB (0x400000) recommended in production
     ARGON_MEMORY_COST = os.environ.get("ARGON_MEMORY_COST", 0x80000)

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -36,6 +36,38 @@ import dds_web.utils
 # Association objects ######################################################## Association objects #
 
 
+class InviteUserKeys(db.Model):
+    """
+    Many-to-many association table between invites and projects. Contains all project private keys encrypted with TKEKs.
+
+    Primary key(s):
+    - project_id
+    - invite_id
+
+    Foreign key(s):
+    - project_id
+    - invite_id
+    """
+
+    # Table setup
+    __tablename__ = "inviteuserkeys"
+
+    # Foreign keys & relationships
+    project_id = db.Column(
+        db.Integer, db.ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
+    )
+    project = db.relationship("Project", back_populates="invite_user_keys")
+    # ---
+    invite_id = db.Column(
+        db.Integer, db.ForeignKey("invites.id", ondelete="CASCADE"), primary_key=True
+    )
+    invite = db.relationship("Invite", back_populates="invite_user_keys")
+    # ---
+
+    # Additional columns
+    key = db.Column(db.LargeBinary(300), nullable=False, unique=True)
+
+
 class ProjectUserKeys(db.Model):
     """
     Many-to-many association table between projects and users (all).
@@ -224,6 +256,9 @@ class Project(db.Model):
     # Additional relationships
     files = db.relationship("File", back_populates="project")
     file_versions = db.relationship("Version", back_populates="project")
+    invite_user_keys = db.relationship(
+        "InviteUserKeys", back_populates="project", passive_deletes=True, cascade="all, delete"
+    )
     project_statuses = db.relationship(
         "ProjectStatuses", back_populates="project", passive_deletes=True, cascade="all, delete"
     )
@@ -678,6 +713,9 @@ class Invite(db.Model):
     # Foreign keys & relationships
     unit_id = db.Column(db.Integer, db.ForeignKey("units.id", ondelete="CASCADE"))
     unit = db.relationship("Unit", back_populates="invites")
+    invite_user_keys = db.relationship(
+        "InviteUserKeys", back_populates="invite", passive_deletes=True, cascade="all, delete"
+    )
     # ---
 
     # Additional columns

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -69,21 +69,50 @@ def get_user_roles_common(user):
 
 
 def verify_token_no_data(token):
-    user, claims = __verify_general_token(token)
+    claims = __verify_general_token(token)
+    user = user_from_subject(claims.get("sub"))
     del claims
     gc.collect()
     return user
 
 
+def verify_invite_token_no_sensdata(token):
+    email, TKEK = verify_invite_token(token)
+    del TKEK
+    gc.collect()
+    return email
+
+
+def verify_invite_token(token):
+    claims = __verify_general_token(token)
+
+    sensitive_content = json.loads(claims["sen_con"])
+
+    # Anyone can post a token to this endpoint so need to be very careful that it's an invite token
+    if "invited_email" not in sensitive_content:
+        raise AuthenticationError(message="Invalid token")
+
+    # I believe this could only happen by mistake on our side, but still worth checking for
+    if claims.get("sub") != sensitive_content["invited_email"]:
+        raise AuthenticationError(message="Invalid token")
+
+    del claims
+    gc.collect()
+
+    return sensitive_content["invited_email"], sensitive_content["TKEK"]
+
+
 @auth.verify_token
 def verify_token(token):
-    user, data = __verify_general_token(token)
-    return handle_multi_factor_authentication(user, data.get("mfa_auth_time"))
+    claims = __verify_general_token(token)
+    user = user_from_subject(claims.get("sub"))
+
+    return handle_multi_factor_authentication(user, claims.get("mfa_auth_time"))
 
 
 def __verify_general_token(token):
     """Verifies the format, signature and expiration time of an encrypted and signed JWT token.
-    Raises ValueError if token is invalid, could raise other exceptions from dependencies.
+    Raises AuthenticationError if token is invalid, could raise other exceptions from dependencies.
 
     If user given by the "sub" claim is found in the database it returns
     (user, claims)
@@ -112,15 +141,18 @@ def __verify_general_token(token):
     if expiration_time and (
         dds_web.utils.current_time() <= datetime.datetime.fromtimestamp(expiration_time)
     ):
-        username = data.get("sub")
-        if username:
-            user = models.User.query.get(username)
-        if user and user.is_active:
-            return user, data
-
-        return None, data
+        return data
 
     raise AuthenticationError(message="Expired token")
+
+
+def user_from_subject(subject):
+    if subject:
+        user = models.User.query.get(subject)
+    if user and user.is_active:
+        return user
+
+    return None
 
 
 def handle_multi_factor_authentication(user, mfa_auth_time_string):

--- a/dds_web/security/project_user_keys.py
+++ b/dds_web/security/project_user_keys.py
@@ -74,6 +74,12 @@ def share_project_private_key_with_user(current_user, existing_user, project):
     )
 
 
+def share_project_private_key_with_invite(current_user, invite, project):
+    __init_and_append_project_invite_key(
+        invite, project, obtain_project_private_key(current_user, project)
+    )
+
+
 def __init_and_append_project_user_key(user, project, project_private_key):
     project_user_key = models.ProjectUserKeys(
         project_id=project.id,
@@ -82,6 +88,17 @@ def __init_and_append_project_user_key(user, project, project_private_key):
     )
     user.project_user_keys.append(project_user_key)
     project.project_user_keys.append(project_user_key)
+
+
+def __init_and_append_project_invite_key(invite, project, project_private_key):
+    invite_user_key = models.InviteUserKeys(
+        project_id=project.id,
+        invite_id=invite.id,
+        # TODO: Replace with real key: project_private_key encrypted with invitees public
+        key=ciphers.aead.AESGCM.generate_key(bit_length=256),
+    )
+    invite.invite_user_keys.append(invite_user_key)
+    project.invite_user_keys.append(invite_user_key)
 
 
 def generate_project_key_pair(user, project):

--- a/dds_web/templates/user/register.html
+++ b/dds_web/templates/user/register.html
@@ -1,68 +1,82 @@
 <html>
-    <head>
-        <title>Registration form</title>
-    </head>
-    <body>
-        <h1>Create your DDS account</h1>
-        <form method="POST" action="{{ url_for('auth_blueprint.register') }}">
-            {{ form.csrf_token }}
 
-            <!-- Name name -->
-            {{ form.name.label }}
-            {{ form.name }}
-            <ul>
-                {% for error in form.name.errors %}
-                <li style="color:red;">
-                    {{ error }}
-                </li>
-                {% endfor %}
-            </ul>
+<head>
+    <title>Registration form</title>
+</head>
 
-            <!-- Email -->
-            {{ form.email.label }}
-            {{ form.email }}
-            <ul>
-                {% for error in form.email.errors %}
-                <li style="color:red;">
-                    {{ error }}
-                </li>
-                {% endfor %}
-            </ul>
+<body>
+    <h1>Create your DDS account</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <div class=flashes>
+        {% for category, message in messages %}
+        <div class="alert alert-{{category}}" role="alert">
+            {{ message }}
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+    {% endwith %}
+    <form method="POST" action="{{ url_for('auth_blueprint.register') }}">
+        {{ form.csrf_token }}
 
-            <!-- Username -->
-            {{ form.username.label }}
-            {{ form.username }}
-            <ul>
-                {% for error in form.username.errors %}
-                <li style="color:red;">
-                    {{ error }}
-                </li>
-                {% endfor %}
-            </ul>
+        <!-- Name name -->
+        {{ form.name.label }}
+        {{ form.name }}
+        <ul>
+            {% for error in form.name.errors %}
+            <li style="color:red;">
+                {{ error }}
+            </li>
+            {% endfor %}
+        </ul>
 
-            <!-- Password -->
-            {{ form.password.label }}
-            {{ form.password }}
-            {{ form.confirm.label }}
-            {{ form.confirm }}
-            <ul>
-                {% for error in form.password.errors %}
-                <li style="color:red;">
-                    {{ error }}
-                </li>
-                {% endfor %}
-            </ul>
+        <!-- Email -->
+        {{ form.email.label }}
+        {{ form.email }}
+        <ul>
+            {% for error in form.email.errors %}
+            <li style="color:red;">
+                {{ error }}
+            </li>
+            {% endfor %}
+        </ul>
+
+        <!-- Username -->
+        {{ form.username.label }}
+        {{ form.username }}
+        <ul>
+            {% for error in form.username.errors %}
+            <li style="color:red;">
+                {{ error }}
+            </li>
+            {% endfor %}
+        </ul>
+
+        <!-- Password -->
+        {{ form.password.label }}
+        {{ form.password }}
+        {{ form.confirm.label }}
+        {{ form.confirm }}
+        <ul>
+            {% for error in form.password.errors %}
+            <li style="color:red;">
+                {{ error }}
+            </li>
+            {% endfor %}
+        </ul>
 
 
-            <!-- Unit -->
-            {% if form.unit_name.data %}
-            Unit name:
-            {{ form.unit_name }}
-            {% endif %}
-            <br>
-            <!-- Submit button -->
-            {{ form.submit }}
+        <!-- Unit -->
+        {% if form.unit_name.data %}
+        Unit name:
+        {{ form.unit_name }}
+        {% endif %}
+        <br>
+        <!-- Submit button -->
+        {{ form.submit }}
 
-        </form>
-    </body>
+    </form>
+</body>
+
 </html>

--- a/dds_web/templates/user/userexists.html
+++ b/dds_web/templates/user/userexists.html
@@ -1,10 +1,10 @@
 {% extends 'user/userbase.html' %}
 {% block body %}
 <h1>Registration completed!</h1>
-<p>You have already successfully created your account at the <span>SciLifeLab Data Delivery
-        System</span>. To get started, please install the <a
-        href="https://github.com/ScilifelabDataCentre/dds_cli">command line application.</a></p>
+<p>You have successfully created your account at the <span>SciLifeLab Data Delivery
+                System</span>. To get started, please install the <a
+                href="https://github.com/ScilifelabDataCentre/dds_cli">command line application.</a></p>
 <p>
-    Instructions how to access and manage your data can be found in the system's <a
-        href="https://github.com/ScilifelabDataCentre/dds_web">documentation.</a></p>
+        Instructions how to access and manage your data can be found in the system's <a
+                href="https://github.com/ScilifelabDataCentre/dds_web">documentation.</a></p>
 {% endblock %}

--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -67,38 +67,35 @@ def index():
 @logging_bind_request
 def confirm_invite(token):
     """Confirm invitation."""
-    s = itsdangerous.URLSafeTimedSerializer(flask.current_app.config.get("SECRET_KEY"))
-
     try:
-        # Get email from token
-        email = s.loads(token, salt="email-confirm", max_age=604800)
+        email = dds_web.security.auth.verify_invite_token_no_sensdata(token)
+    except Exception as err:
+        flask.flash("This invitation link has expired or is invalid.", "danger")
+        return flask.redirect(flask.url_for("auth_blueprint.index"))
 
-        # Get row from invite table
-        invite_row = models.Invite.query.filter(models.Invite.email == email).first()
-
-    except itsdangerous.exc.SignatureExpired as signerr:
-        db.session.delete(invite_row)
-        db.session.commit()
-        raise  # TODO: Do not raise api error here, should fix new error handling for web page
-    except (itsdangerous.exc.BadSignature, itsdangerous.exc.BadTimeSignature) as badsignerr:
-        raise
-    except sqlalchemy.exc.SQLAlchemyError as sqlerr:
-        raise
+    # Get row from invite table
+    invite_row = models.Invite.query.filter(models.Invite.email == email).first()
 
     # Check the invite exists
     if not invite_row:
         if dds_web.utils.email_in_db(email=email):
+            flask.flash("Registration already completed.")
             return flask.make_response(flask.render_template("user/userexists.html"))
         else:
-            raise ddserr.InviteError(
-                message=f"There is no pending invitation for the email adress: {email}"
-            )
+            flask.flash("This invitation link has expired or is invalid.", "danger")
+            return flask.redirect(flask.url_for("auth_blueprint.index"))
 
-    # Initiate form if the invite exists
+    # Save encrypted token to be reused at registration
+    # token is in the session already if the user refreshes the page
+    if not "invite_token" in flask.session:
+        # New visit or session has expired
+        flask.session["invite_token"] = token
+
     form = forms.RegistrationForm()
-    # invite columns: unit_id, email, role
 
-    # Prefill fields - facility readonly if filled, otherwise disabled
+    # Prefill fields - unit readonly if filled, otherwise disabled
+    # These should only be used for display to user and not when actually registering
+    # the user, then the values should be fetched from the database again.
     form.unit_name.render_kw = {"disabled": True}
     if invite_row.unit:  # backref to unit
         form.unit_name.data = invite_row.unit.name
@@ -122,19 +119,41 @@ def confirm_invite(token):
 )
 def register():
     """Handles the creation of a new user"""
+    token = flask.session.get("invite_token")
+
     form = dds_web.forms.RegistrationForm()
+
+    # Two reasons are possible for the token to be None.
+    # The most likely reason is that the session has expired (given by PERMANENT_SESSION_LIFETIME config variable)
+    # Less likely is that the confirm_invite was not called before posting the registration form.
+    if token is None:
+        flask.current_app.logger.info("No token found in session when posting to register.")
+        flask.flash(
+            "Error in registration process, please go back and use the link in the invitation email again."
+        )
+        return flask.redirect(flask.url_for("auth_blueprint.index"))
+
+    # This method can raise exceptions, but they should occur very rarely since token should be verified
+    # and therefore we don't need any special message to user.
+    token_email, TKEK = dds_web.security.auth.verify_invite_token(token)
 
     # Validate form - validators defined in form class
     if form.validate_on_submit():
         # Create new user row by loading form data into schema
         try:
-            new_user = user_schemas.NewUserSchema().load(form.data)
+            new_user = user_schemas.NewUserSchema().load(
+                {**form.data, "token_email": token_email, "TKEK": TKEK}
+            )
+        except Exception as err:
+            # This should never happen since the form is validated
+            # Any error catched here is likely a bug/issue
+            flask.current_app.logger.warning(err)
+            flask.flash("Error in registration process, please try again.")
+            return flask.redirect(flask.url_for("auth_blueprint.index"))
 
-        except marshmallow.ValidationError as valerr:
-            flask.current_app.logger.warning(valerr)
-            raise
-        except (sqlalchemy.exc.SQLAlchemyError, sqlalchemy.exc.IntegrityError) as sqlerr:
-            raise ddserr.DatabaseError from sqlerr
+        flask.session.pop("invite_token", None)
+        flask.flash("Registration successful!")
+        return flask.make_response(flask.render_template("user/userexists.html"))
 
     # Go to registration form
     return flask.render_template("user/register.html", form=form)


### PR DESCRIPTION
Rough draft to add Invitees to projects:

Main issue with Invitees is that they have not yet a corresponding user in the system. Therefore, all the neat functionalities of a regular user including all key handling routines will not be fully functional. 
 
Hence, this PR introduces a new table `InviteUserKeys` #829 , that holds encrypted project private keys linked to the project and the invite. Because it is build analogously to the `ProjectUserKeys`, it's contents should be easily transferable to said table once a User exists after registration of the invitee. 

ToDO:
- TKEK (generation in the `InviteUserSchema`?)
- Retrieval of the `InviteUserKeys` in `NewUserSchema` and transfer into `ProjectUserKeys`
- Invites by ProjectOwners 
- Invites linked to multiple projects (incompatible with project in the request.args?)