### PR TITLE
Add new line so that the token is clearly displayed

### DIFF
--- a/dds_web/utils.py
+++ b/dds_web/utils.py
@@ -234,9 +234,9 @@ def send_reset_email(email_row):
         recipients=[email_row.email],
     )
     message.body = (
-        "To reset your password, visit the following link: "
+        "To reset your password, visit the following link:\n"
         f"{flask.url_for('auth_blueprint.reset_password', token=token, _external=True)}"
-        "If you did not make this request then simply ignore this email and no changes will be made."
+        "\n\nIf you did not make this request then simply ignore this email and no changes will be made."
     )
     mail.send(message)
 


### PR DESCRIPTION
In the reset email received by the user the `If` in the following sentence was concatenated with the end of the token in the email, so we were copying the If with the token accidentally. The mail looked like 
`To reset your password, visit the following link: http://127.0.0.1:5000/reset_password/xxxtokenyyyIf you did not make this request then simply ignore this email and no changes will be made.`

The functionality is not broken as it is.