### PR TITLE
Session instead of cookie

### DIFF
--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -201,7 +201,7 @@ def confirm_2fa():
         )
         return flask.redirect(flask.url_for("auth_blueprint.login", next=next))
 
-    # Valid invite token, but user does not exist (should never happen)
+    # Valid 2fa initiated token, but user does not exist (should never happen)
     if not user:
         flask.session.pop("2fa_initiated_token", None)
         flask.flash("Error: Internal error.", "danger")

--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -227,6 +227,7 @@ def confirm_2fa():
         flask.flash("Logged in successfully.")
         # Remove token from session
         flask.session.pop("2fa_initiated_token", None)
+        # Next is assured to be url_safe above
         return flask.redirect(next or flask.url_for("auth_blueprint.index"))
 
     else:

--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -158,10 +158,8 @@ def register():
     error_message=ddserr.TooManyRequestsError.description,
 )
 def cancel_2fa():
-    # Reset 2fa cookie
-    redirect_to_login = flask.redirect(flask.url_for("auth_blueprint.login"))
-    redirect_to_login.set_cookie("2fa_initiated_token", "", expires=0)
-    return redirect_to_login
+    flask.session.pop("2fa_initiated_token", None)
+    return flask.redirect(flask.url_for("auth_blueprint.login"))
 
 
 @auth_blueprint.route("/confirm_2fa", methods=["GET", "POST"])
@@ -186,19 +184,30 @@ def confirm_2fa():
     if next and not dds_web.utils.is_safe_url(next):
         return flask.abort(400)
 
+    # Check user has initiated 2FA
+    token = flask.session.get("2fa_initiated_token")
+    try:
+        user = dds_web.security.auth.verify_token_no_data(token)
+    except ddserr.AuthenticationError:
+        flask.flash(
+            f"Error: Please initiate a log in before entering the one-time authentication code."
+        )
+        return flask.redirect(flask.url_for("auth_blueprint.login", next=next))
+    except Exception as e:
+        flask.current_app.logger.exception(e)
+        flask.flash(
+            "Error: Second factor could not be validated due to an internal server error.",
+            "danger",
+        )
+        return flask.redirect(flask.url_for("auth_blueprint.login", next=next))
+
+    # Valid invite token, but user does not exist (should never happen)
+    if not user:
+        flask.session.pop("2fa_initiated_token", None)
+        flask.flash("Error: Internal error.", "danger")
+        return flask.redirect(flask.url_for("auth_blueprint.login", next=next))
+
     if form.validate_on_submit():
-        try:
-            token = flask.session.get("2fa_intiated_token")
-            user = dds_web.security.auth.verify_token_no_data(token)
-        except ddserr.AuthenticationError as e:
-            flask.flash(f"Error: Second factor could not be validated due to: {e}", "danger")
-            return flask.redirect(flask.url_for("auth_blueprint.login", next=next))
-        except Exception as e:
-            flask.current_app.logger.exception(e)
-            flask.flash(
-                "Error: Second factor could not be validated due to an unknown error", "danger"
-            )
-            return flask.redirect(flask.url_for("auth_blueprint.login", next=next))
 
         hotp_value = form.hotp.data
 
@@ -215,11 +224,10 @@ def confirm_2fa():
 
         # Correct username, password and hotp code --> log user in
         flask_login.login_user(user)
-        # Remove token from cookies and make it expired
         flask.flash("Logged in successfully.")
-        redirect_to_index = flask.redirect(next or flask.url_for("auth_blueprint.index"))
-        redirect_to_index.set_cookie("2fa_initiated_token", "", expires=0)
-        return redirect_to_index
+        # Remove token from session
+        flask.session.pop("2fa_initiated_token", None)
+        return flask.redirect(next or flask.url_for("auth_blueprint.index"))
 
     else:
         return flask.render_template(

--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -177,7 +177,7 @@ def confirm_2fa():
 
     if form.validate_on_submit():
         try:
-            token = flask.request.cookies["2fa_initiated_token"]
+            token = flask.session.get("2fa_intiated_token")
             user = dds_web.security.auth.verify_token_no_data(token)
         except ddserr.AuthenticationError as e:
             flask.flash(f"Error: Second factor could not be validated due to: {e}", "danger")
@@ -262,9 +262,8 @@ def login():
             user.username, expires_in=datetime.timedelta(minutes=15)
         )
 
-        redirect_to_confirm = flask.redirect(flask.url_for("auth_blueprint.confirm_2fa", next=next))
-        redirect_to_confirm.set_cookie("2fa_initiated_token", token_2fa_initiated)
-        return redirect_to_confirm
+        flask.session["2fa_initiated_token"] = token_2fa_initiated
+        return flask.redirect(flask.url_for("auth_blueprint.confirm_2fa", next=next))
 
     # Go to login form (get)
     return flask.render_template("user/login.html", form=form, next=next)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -125,6 +125,8 @@ class DDSEndpoint:
     # Web
     INDEX = "/"
     LOGIN = "/login"
+    CANCEL_2FA = "/cancel_2fa"
+    CONFIRM_2FA = "/confirm_2fa"
 
     # User creation
     USER_ADD = BASE_ENDPOINT + "/user/add"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -122,6 +122,10 @@ class DDSEndpoint:
     # Base url - local or remote
     BASE_ENDPOINT = "/api/v1"
 
+    # Web
+    INDEX = "/"
+    LOGIN = "/login"
+
     # User creation
     USER_ADD = BASE_ENDPOINT + "/user/add"
     USER_CONFIRM = "/confirm_invite/"

--- a/tests/test_login_web.py
+++ b/tests/test_login_web.py
@@ -1,0 +1,45 @@
+import tests
+import flask
+from dds_web import db
+from dds_web.database import models
+import dds_web.errors as ddserr
+from dds_web.security.tokens import encrypted_jwt_token
+import datetime
+
+
+def test_cancel_2fa(client):
+    user_auth = tests.UserAuth(tests.USER_CREDENTIALS["researcher"])
+
+    response = client.get(tests.DDSEndpoint.LOGIN)
+    assert response.status == "200 OK"
+
+    form_token = flask.g.csrf_token
+
+    form_data = {
+        "csrf_token": form_token,
+        "username": user_auth.as_tuple()[0],
+        "password": user_auth.as_tuple()[1],
+        "submit": "Login",
+    }
+
+    response = client.post(
+        tests.DDSEndpoint.LOGIN,
+        json=form_data,
+        follow_redirects=True,
+    )
+    assert response.status == "200 OK"
+    assert flask.request.path == tests.DDSEndpoint.CONFIRM_2FA
+
+    second_factor_token = flask.session.get("2fa_initiated_token")
+    assert second_factor_token is not None
+
+    response = client.post(
+        tests.DDSEndpoint.CANCEL_2FA,
+        follow_redirects=True,
+    )
+
+    assert response.status == "200 OK"
+    assert flask.request.path == tests.DDSEndpoint.LOGIN
+
+    second_factor_token = flask.session.get("2fa_initiated_token")
+    assert second_factor_token is None

--- a/tests/test_user_invite.py
+++ b/tests/test_user_invite.py
@@ -1,4 +1,3 @@
-import json
 import tests
 import flask
 from dds_web import db

--- a/tests/test_user_invite.py
+++ b/tests/test_user_invite.py
@@ -68,6 +68,11 @@ def test_valid_token(client):
     assert b"Registration form" in response.data
 
 
+def test_register_no_form(client):
+    response = client.post(tests.DDSEndpoint.USER_NEW, content_type="application/json")
+    assert response.status == "400 BAD REQUEST"
+
+
 def test_register_no_token_in_session(client):
     invite = models.Invite.query.filter_by(
         email="existing_invite_email@mailtrap.io", role="Researcher"

--- a/tests/test_user_new.py
+++ b/tests/test_user_new.py
@@ -1,7 +1,0 @@
-import json
-import tests
-
-
-def test_no_form(client):
-    response = client.post(tests.DDSEndpoint.USER_NEW, content_type="application/json")
-    assert response.status == "400 BAD REQUEST"


### PR DESCRIPTION
1. Use session cookie instead of regular cookie for 2fa initiated token
2. Check that token exists already at the GET request of `confirm_2fa`
3. Added check for case when session token is valdi but user does not exist (happens during testing if user is deleted in-between login and confirm_2fa).