### PR TITLE
Issue860 invites multiple projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 # Data Delivery System Web / API: Changelog
+
 Please add a _short_ line describing the PR you make, if the PR implements a specific feature or functionality, or refactor. Not needed if you add very small and unnoticable changes.
+
+- [PR888](https://github.com/ScilifelabDataCentre/dds_web/pull/888) implemented the functionality to add project to the invites of a new user as outlined in [issue 887](https://github.com/scilifelabdatacentre/dds_web/issues/887).

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -417,7 +417,8 @@ class CreateProject(flask_restful.Resource):
                         {
                             "email": user.get("email"),
                             "role": user.get("role"),
-                        }
+                        },
+                        project=new_project,
                     )
                     if invite_user_result["status"] == 200:
                         invite_msg = (
@@ -431,9 +432,9 @@ class CreateProject(flask_restful.Resource):
                     # If it is an existing user, add them to project.
                     addition_status = ""
                     try:
-                        add_user_result = AddUser.add_user_to_project(
-                            existing_user=existing_user,
-                            project=new_project.public_id,
+                        add_user_result = AddUser.add_to_project(
+                            whom=existing_user,
+                            project=new_project,
                             role=user.get("role"),
                         )
                     except DatabaseError as err:

--- a/dds_web/api/schemas/user_schemas.py
+++ b/dds_web/api/schemas/user_schemas.py
@@ -90,15 +90,11 @@ class InviteUserSchema(marshmallow.Schema):
         elif curr_user_role == "Unit Personnel":
             if attempted_invite_role in ["Super Admin", "Unit Admin"]:
                 raise ddserr.AccessDeniedError
-        elif curr_user_role == "Researcher":
-            # research users can only invite in certain projects if they are set as the owner
-            # TODO: Add required project field for researchers to be able to invite (if
-            raise ddserr.AccessDeniedError(
-                message=(
-                    "Research users cannot invite at this time. "
-                    "Project owner invite config will be fixed."
-                )
-            )
+        elif (
+            curr_user_role == "Researcher"
+        ):  # project ownership is validated in @basic_auth.get_user_roles
+            if attempted_invite_role not in ["Researcher", "Project Owner"]:
+                raise ddserr.AccessDeniedError
 
     @marshmallow.post_load
     def make_invite(self, data, **kwargs):

--- a/dds_web/api/schemas/user_schemas.py
+++ b/dds_web/api/schemas/user_schemas.py
@@ -40,6 +40,23 @@ class UserSchema(marshmallow.Schema):
         return email_row.user
 
 
+class UnansweredInvite(marshmallow.Schema):
+    """Schema to return an unanswered invite."""
+
+    email = marshmallow.fields.Email(required=True)
+
+    class Meta:
+        unknown = marshmallow.EXCLUDE
+
+    @marshmallow.post_load
+    def return_invite(self, data, **kwargs):
+        """Return the invite object."""
+        # returns the invite, if there is exactly one or raises an exception.
+        # returns none, if there is no invite
+        invite = models.Invite.query.filter_by(email=data.get("email")).one_or_one()
+        return invite
+
+
 class InviteUserSchema(marshmallow.Schema):
     """Schema for AddUser endpoint"""
 

--- a/dds_web/api/schemas/user_schemas.py
+++ b/dds_web/api/schemas/user_schemas.py
@@ -53,7 +53,7 @@ class UnansweredInvite(marshmallow.Schema):
         """Return the invite object."""
         # returns the invite, if there is exactly one or raises an exception.
         # returns none, if there is no invite
-        invite = models.Invite.query.filter_by(email=data.get("email")).one_or_one()
+        invite = models.Invite.query.filter_by(email=data.get("email")).one_or_none()
         return invite
 
 

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -51,7 +51,7 @@ class AddUser(flask_restful.Resource):
         project = flask.request.args.get("project", None)
         if project:
             project = project_schemas.ProjectRequiredSchema().load({"project": project})
-            role = args.get("role", None)
+            role = flask.request.json.get("role", None)
 
         args = flask.request.json
         # Check if email is registered to a user

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -197,7 +197,7 @@ class AddUser(flask_restful.Resource):
             link = project.invites
 
         for rusers in link:
-            if rusers.researchuser is whom:
+            if rusers.researchuser == whom:
                 if rusers.owner == owner:
                     return {
                         "status": ddserr.RoleException.code.value,

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -355,6 +355,11 @@ class Project(db.Model):
 
         return len(self.files)
 
+    def __str__(self):
+        """Called by str(), creates representation of object"""
+
+        return f"Project {self.public_id}"
+
     def __repr__(self):
         """Called by print, creates representation of object"""
 
@@ -538,6 +543,11 @@ class User(flask_login.UserMixin, db.Model):
     @property
     def is_active(self):
         return self.active
+
+    def __str__(self):
+        """Called by str(), creates representation of object"""
+
+        return f"User {self.username}"
 
     def __repr__(self):
         """Called by print, creates representation of object"""
@@ -767,6 +777,11 @@ class Invite(db.Model):
         """Return list of project items."""
 
         return [proj.project for proj in self.project_associations]
+
+    def __str__(self):
+        """Called by str(), creates representation of object"""
+
+        return f"Pending invite for {self.email}"
 
     def __repr__(self):
         """Called by print, creates representation of object"""

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -122,7 +122,7 @@ class ProjectInvites(db.Model):
     )
     project = db.relationship("Project", back_populates="invites")
     # ---
-    researchuser_id = db.Column(
+    invite_id = db.Column(
         db.Integer, db.ForeignKey("invites.id", ondelete="CASCADE"), primary_key=True
     )
     # researchuser was kept for consistency with ResearchUser model.

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -114,7 +114,7 @@ class ProjectInvites(db.Model):
     """
 
     # Table setup
-    __tablename__ = "projectusers"
+    __tablename__ = "projectinvites"
 
     # Foreign keys & relationships
     project_id = db.Column(
@@ -122,7 +122,7 @@ class ProjectInvites(db.Model):
     )
     project = db.relationship("Project", back_populates="invites")
     # ---
-    invite_id = db.Column(
+    researchuser_id = db.Column(
         db.Integer, db.ForeignKey("researchusers.id", ondelete="CASCADE"), primary_key=True
     )
     # researchuser was kept for consistency with ResearchUser model.

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -123,7 +123,7 @@ class ProjectInvites(db.Model):
     project = db.relationship("Project", back_populates="invites")
     # ---
     researchuser_id = db.Column(
-        db.Integer, db.ForeignKey("researchusers.id", ondelete="CASCADE"), primary_key=True
+        db.Integer, db.ForeignKey("invites.id", ondelete="CASCADE"), primary_key=True
     )
     # researchuser was kept for consistency with ResearchUser model.
     researchuser = db.relationship("Invite", back_populates="project_associations")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,7 +295,7 @@ def demo_data():
             ),
         )
 
-    invites = [Invite(email="existing_invite_email@mailtrap.io", role="Researcher")]
+    invites = [Invite(**{"email": "existing_invite_email@mailtrap.io", "role": "Researcher"})]
 
     return (units, users, projects, invites, files_and_versions)
 

--- a/tests/test_project_creation.py
+++ b/tests/test_project_creation.py
@@ -300,7 +300,7 @@ def test_create_project_with_users(client, boto3_session):
     assert response.status == "200 OK"
     assert response.json and response.json.get("user_addition_statuses")
     for x in response.json.get("user_addition_statuses"):
-        assert "associated with project" in x
+        assert "associated with Project" in x
 
     resp_json = response.json
     created_proj = models.Project.query.filter_by(public_id=resp_json["project_id"]).one_or_none()

--- a/tests/test_user_add.py
+++ b/tests/test_user_add.py
@@ -7,8 +7,11 @@ import tests
 import pytest
 import marshmallow
 
+existing_project = "public_project_id"
 first_new_email = {"email": "first_test_email@mailtrap.io"}
 first_new_user = {**first_new_email, "role": "Researcher"}
+first_new_owner = {**first_new_email, "role": "Project Owner"}
+first_new_user_existing_project = {**first_new_user, "project": "public_project_id"}
 first_new_user_extra_args = {**first_new_user, "extra": "test"}
 first_new_user_invalid_role = {**first_new_email, "role": "Invalid Role"}
 first_new_user_invalid_email = {"email": "first_invalid_email", "role": first_new_user["role"]}
@@ -426,3 +429,156 @@ def test_add_existing_user_with_unsuitable_role(client):
         content_type="application/json",
     )
     assert response.status_code == http.HTTPStatus.FORBIDDEN
+
+
+### Tests for Invite-Project associations ###
+
+
+def test_new_invite_with_project_by_unituser(client):
+    "Test that a new invite including a project can be created"
+
+    project = existing_project
+    response = client.post(
+        tests.DDSEndpoint.USER_ADD,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
+        query_string={"project": project},
+        data=json.dumps(first_new_user),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    invited_user = models.Invite.query.filter_by(email=first_new_user["email"]).one_or_none()
+    assert invited_user
+    assert invited_user.email == first_new_user["email"]
+    assert invited_user.role == first_new_user["role"]
+
+    assert invited_user.nonce is not None
+    assert invited_user.public_key is not None
+    assert invited_user.private_key is not None
+
+    project_associations = invited_user.project_associations
+    assert len(project_associations) == 1
+    assert project_associations[0].project.public_id == project
+
+    project_invite_keys = invited_user.project_invite_keys
+    assert len(project_invite_keys) == 1
+    assert project_invite_keys[0].project.public_id == project
+
+
+def test_add_project_to_existing_invite_by_unituser(client):
+    "Test that a project can be associated with an existing invite"
+
+    # Create invite upfront
+
+    project = existing_project
+    response = client.post(
+        tests.DDSEndpoint.USER_ADD,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
+        data=json.dumps(first_new_user),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    invited_user = models.Invite.query.filter_by(email=first_new_user["email"]).one_or_none()
+
+    # Check that the invite has no projects yet
+
+    assert invited_user
+    assert len(invited_user.project_associations) == 0
+    assert len(invited_user.project_invite_keys) == 0
+
+    # Add project to existing invite
+
+    response = client.post(
+        tests.DDSEndpoint.USER_ADD,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
+        query_string={"project": project},
+        data=json.dumps(first_new_user),
+        content_type="application/json",
+    )
+
+    assert response.status_code == http.HTTPStatus.OK
+
+    # Check that the invite has now a project association
+
+    project_associations = invited_user.project_associations
+    assert len(project_associations) == 1
+    assert project_associations[0].project.public_id == project
+
+    project_invite_keys = invited_user.project_invite_keys
+    assert len(project_invite_keys) == 1
+    assert project_invite_keys[0].project.public_id == project
+
+
+def test_update_project_to_existing_invite_by_unituser(client):
+    "Test that project ownership can be updated for an existing invite"
+
+    # Create Invite upfront
+
+    project = existing_project
+    response = client.post(
+        tests.DDSEndpoint.USER_ADD,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
+        query_string={"project": project},
+        data=json.dumps(first_new_user),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    project_obj = models.Project.query.filter_by(public_id=existing_project).one_or_none()
+    invite_obj = models.Invite.query.filter_by(email=first_new_user["email"]).one_or_none()
+
+    project_invite = models.ProjectInvites.query.filter(
+        sqlalchemy.and_(
+            models.ProjectInvites.invite_id == invite_obj.id,
+            models.ProjectUsers.project_id == project_obj.id,
+        )
+    ).one_or_none()
+
+    assert project_invite
+    assert not project_invite.owner
+
+    response = client.post(
+        tests.DDSEndpoint.USER_ADD,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
+        query_string={"project": project},
+        data=json.dumps(first_new_owner),
+        content_type="application/json",
+    )
+
+    assert response.status_code == http.HTTPStatus.OK
+
+    db.session.refresh(project_invite)
+
+    assert project_invite.owner
+
+
+def test_invite_to_project_by_project_owner(client):
+    "Test that a project owner can invite to its project"
+
+    project = existing_project
+    response = client.post(
+        tests.DDSEndpoint.USER_ADD,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["projectowner"]).token(client),
+        query_string={"project": project},
+        data=json.dumps(first_new_user),
+        content_type="application/json",
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    invited_user = models.Invite.query.filter_by(email=first_new_user["email"]).one_or_none()
+    assert invited_user
+    assert invited_user.email == first_new_user["email"]
+    assert invited_user.role == first_new_user["role"]
+
+    assert invited_user.nonce is not None
+    assert invited_user.public_key is not None
+    assert invited_user.private_key is not None
+
+    project_associations = invited_user.project_associations
+    assert len(project_associations) == 1
+    assert project_associations[0].project.public_id == project
+
+    project_invite_keys = invited_user.project_invite_keys
+    assert len(project_invite_keys) == 1
+    assert project_invite_keys[0].project.public_id == project


### PR DESCRIPTION
This PR addresses one part of #860 and closes #887: Attaching project associations with new or pending invites. 

Since we intended to be as atomic as possible with the PRs, the scope of this one is only to create the respective records in the database. Moving Keys and Projects from the Invite tables to the analogous User tables will be addressed in another PR.

Another ToDo for the CLI is actually to loop through multiple projects and users.
