### PR TITLE
Key derivation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+Before submitting a pr:
+- [ ] Tests passing
+- [ ] Black formatting
+- [ ] Rebase/merge the `dev` branch
+- [ ] Note in the CHANGELOG
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 # Data Delivery System Web / API: Changelog
 Please add a _short_ line describing the PR you make, if the PR implements a specific feature or functionality, or refactor. Not needed if you add very small and unnoticable changes.
+
+## Sprint (2022-02-09 - 2022-02-23)
+* Secure operations that require cryptographic keys are protected for each user with the user's password ([#889](https://github.com/ScilifelabDataCentre/dds_web/pull/889))

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -240,7 +240,15 @@ class GetPrivate(flask_restful.Resource):
         flask.current_app.logger.debug("Getting the private key.")
 
         return flask.jsonify(
-            {"private": obtain_project_private_key(auth.current_user(), project).hex().upper()}
+            {
+                "private": obtain_project_private_key(
+                    user=auth.current_user(),
+                    project=project,
+                    token=dds_web.security.auth.obtain_current_encrypted_token(),
+                )
+                .hex()
+                .upper()
+            }
         )
 
 

--- a/dds_web/api/schemas/user_schemas.py
+++ b/dds_web/api/schemas/user_schemas.py
@@ -14,7 +14,7 @@ import dds_web
 from dds_web import auth, db, utils
 from dds_web import errors as ddserr
 from dds_web.database import models
-from dds_web.security.project_user_keys import transfer_invite_private_key_to_user
+from dds_web.security.project_user_keys import verify_and_transfer_invite_to_user
 
 ####################################################################################################
 # SCHEMAS ################################################################################ SCHEMAS #
@@ -196,9 +196,7 @@ class NewUserSchema(marshmallow.Schema):
         db.session.add(new_user)
 
         # Verify and transfer invite keys to the new user
-        temporary_key = dds_web.security.auth.verify_invite_key(token)
-        if temporary_key:
-            transfer_invite_private_key_to_user(invite, temporary_key, new_user)
+        if verify_and_transfer_invite_to_user(token, new_user, data.get("password")):
             for project_invite_key in invite.project_invite_keys:
                 project_user_key = models.ProjectUserKeys(
                     project_id=project_invite_key.project_id,
@@ -207,9 +205,6 @@ class NewUserSchema(marshmallow.Schema):
                 )
                 db.session.add(project_user_key)
                 db.session.delete(project_invite_key)
-
-            # TODO decrypt the user private key using the temp key,
-            #  derive a key from the password and encrypt the user private key with the derived key
 
             flask.session.pop("invite_token", None)
 

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -64,7 +64,7 @@ class Config(object):
     INVITATION_EXPIRES_IN_HOURS = 7 * 24
 
     # 512MiB; at least 4GiB (0x400000) recommended in production
-    ARGON_MEMORY_COST = os.environ.get("ARGON_MEMORY_COST", 0x80000)
+    ARGON_KD_MEMORY_COST = os.environ.get("ARGON_KD_MEMORY_COST", 0x80000)
 
     SUPERADMIN_USERNAME = os.environ.get("DDS_SUPERADMIN_USERNAME", "superadmin")
     SUPERADMIN_PASSWORD = os.environ.get("DDS_SUPERADMIN_PASSWORD", "password")

--- a/dds_web/development/db_init.py
+++ b/dds_web/development/db_init.py
@@ -17,6 +17,7 @@ from dds_web.security.project_user_keys import (
     generate_project_key_pair,
     share_project_private_key,
 )
+from dds_web.security.tokens import encrypted_jwt_token
 import dds_web.utils
 
 ####################################################################################################
@@ -154,7 +155,23 @@ def fill_db():
 
     db.session.commit()
 
-    share_project_private_key(unituser_1, researchuser_1, project_1)
-    share_project_private_key(unituser_1, researchuser_2, project_1)
+    unituser_1_token = encrypted_jwt_token(
+        username=unituser_1.username,
+        sensitive_content=password,
+    )
+
+    share_project_private_key(
+        from_user=unituser_1,
+        to_another=researchuser_1,
+        from_user_token=unituser_1_token,
+        project=project_1,
+    )
+
+    share_project_private_key(
+        from_user=unituser_1,
+        to_another=researchuser_2,
+        from_user_token=unituser_1_token,
+        project=project_1,
+    )
 
     db.session.commit()

--- a/dds_web/errors.py
+++ b/dds_web/errors.py
@@ -10,14 +10,12 @@ import logging
 # Installed
 from werkzeug import exceptions
 import flask
-import dds_web
-import flask_login
 import http
 import json
 import structlog
 
 # Own modules
-from dds_web import actions, auth
+from dds_web import auth
 
 ####################################################################################################
 # LOGGING ################################################################################ LOGGING #
@@ -71,6 +69,50 @@ class KeyLengthError(SystemExit):
         super().__init__(message)
 
         general_logger.error(message)
+
+
+class TokenMissingError(LoggedHTTPException):
+    """Errors due to missing token."""
+
+    code = http.HTTPStatus.BAD_REQUEST
+
+    def __init__(self, message="Token is missing"):
+        super().__init__(message)
+
+        general_logger.warning(message)
+
+
+class SensitiveContentMissingError(LoggedHTTPException):
+    """Errors due to missing sensitive content in the encrypted token."""
+
+    code = http.HTTPStatus.BAD_REQUEST
+
+    def __init__(self, message="Sensitive content is missing in the encrypted token!"):
+        super().__init__(message)
+
+        general_logger.warning(message)
+
+
+class KeySetupError(LoggedHTTPException):
+    """Errors due to missing keys."""
+
+    code = http.HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def __init__(self, message="Keys are not properly setup!"):
+        super().__init__(message)
+
+        general_logger.warning(message)
+
+
+class KeyOperationError(LoggedHTTPException):
+    """Errors due to issues in key operations."""
+
+    code = http.HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def __init__(self, message="A key cannot be processed!"):
+        super().__init__(message)
+
+        general_logger.warning(message)
 
 
 class AuthenticationError(LoggedHTTPException):

--- a/dds_web/forms.py
+++ b/dds_web/forms.py
@@ -3,17 +3,14 @@
 # IMPORTS ################################################################################ IMPORTS #
 
 # Standard library
-import re
 
 # Installed
 import flask_wtf
 import flask_login
 import wtforms
-import marshmallow
 
 # Own modules
 from dds_web import utils
-from dds_web.database import models
 
 # FORMS #################################################################################### FORMS #
 

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -18,9 +18,8 @@ import structlog
 
 # Own modules
 from dds_web import basic_auth, auth, mail
-from dds_web.errors import AuthenticationError, AccessDeniedError, InviteError
+from dds_web.errors import AuthenticationError, AccessDeniedError, InviteError, TokenMissingError
 from dds_web.database import models
-from dds_web.security.project_user_keys import verify_invite_temporary_key
 import dds_web.utils
 
 action_logger = structlog.getLogger("actions")
@@ -135,8 +134,11 @@ def matching_email_with_invite(token, email):
     return claims.get("inv") == email
 
 
-def verify_invite_key(token):
-    """Verify token, email, invite and temporary key."""
+def extract_token_invite_key(token):
+    """Verify token, email and invite.
+
+    Return invite and temporary key.
+    """
     claims = __base_verify_token_for_invite(token=token)
 
     # Verify email in token
@@ -149,19 +151,29 @@ def verify_invite_key(token):
     if not invite:
         raise InviteError(message="Invite could not be found!")
 
-    # Verify temporary key from token claims
-    temporary_key = bytes.fromhex(claims.get("sen_con"))
-    if verify_invite_temporary_key(invite=invite, temporary_key=temporary_key):
-        return temporary_key
+    return invite, bytes.fromhex(claims.get("sen_con"))
+
+
+def obtain_current_encrypted_token():
+    try:
+        return flask.request.headers["Authorization"].split()[1]
+    except KeyError:
+        raise TokenMissingError("Encrypted token is required but missing!")
+
+
+def obtain_current_encrypted_token_claims():
+    token = obtain_current_encrypted_token()
+    if token:
+        return decrypt_and_verify_token_signature(token)
 
 
 @auth.verify_token
 def verify_token(token):
-    """Verify token used in token authencation."""
+    """Verify token used in token authentication."""
     claims = __verify_general_token(token=token)
     user = __user_from_subject(subject=claims.get("sub"))
 
-    return handle_multi_factor_authentication(
+    return __handle_multi_factor_authentication(
         user=user, mfa_auth_time_string=claims.get("mfa_auth_time")
     )
 
@@ -209,7 +221,7 @@ def __user_from_subject(subject):
             return user
 
 
-def handle_multi_factor_authentication(user, mfa_auth_time_string):
+def __handle_multi_factor_authentication(user, mfa_auth_time_string):
     """Verify multifactor authentication time frame."""
     if user:
         if mfa_auth_time_string:
@@ -245,8 +257,10 @@ def send_hotp_email(user):
     return False
 
 
-def extract_encrypted_token_content(token, username):
+def extract_encrypted_token_sensitive_content(token, username):
     """Extract the sensitive content from inside the encrypted token."""
+    if token is None:
+        raise TokenMissingError(message="There is no token to extract sensitive content from.")
     content = decrypt_and_verify_token_signature(token=token)
     if content.get("sub") == username:
         return content.get("sen_con")

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -151,7 +151,10 @@ def extract_token_invite_key(token):
     if not invite:
         raise InviteError(message="Invite could not be found!")
 
-    return invite, bytes.fromhex(claims.get("sen_con"))
+    try:
+        return invite, bytes.fromhex(claims.get("sen_con"))
+    except ValueError:
+        raise ValueError("Temporary key is expected be in hexadecimal digits for a byte string.")
 
 
 def obtain_current_encrypted_token():

--- a/dds_web/security/project_user_keys.py
+++ b/dds_web/security/project_user_keys.py
@@ -28,7 +28,7 @@ def __derive_key(user, password):
         secret=password.encode(),
         salt=user.kd_salt,
         time_cost=2,
-        memory_cost=flask.current_app.config["ARGON_MEMORY_COST"],
+        memory_cost=flask.current_app.config["ARGON_KD_MEMORY_COST"],
         parallelism=8,
         hash_len=32,
         type=argon2.Type.ID,

--- a/dds_web/security/project_user_keys.py
+++ b/dds_web/security/project_user_keys.py
@@ -95,7 +95,7 @@ def __decrypt_project_private_key(user, token, encrypted_project_private_key):
         raise KeyOperationError(message="User private key could not be loaded!")
 
 
-def obtain_project_private_key(user, token, project):
+def obtain_project_private_key(user, project, token):
     project_key = models.ProjectUserKeys.query.filter_by(
         project_id=project.id, user_id=user.username
     ).first()
@@ -107,11 +107,19 @@ def obtain_project_private_key(user, token, project):
 def share_project_private_key(from_user, to_another, from_user_token, project):
     if isinstance(to_another, models.Invite):
         __init_and_append_project_invite_key(
-            to_another, project, obtain_project_private_key(from_user, from_user_token, project)
+            invite=to_another,
+            project=project,
+            project_private_key=obtain_project_private_key(
+                user=from_user, project=project, token=from_user_token
+            ),
         )
     else:
         __init_and_append_project_user_key(
-            to_another, project, obtain_project_private_key(from_user, from_user_token, project)
+            user=to_another,
+            project=project,
+            project_private_key=obtain_project_private_key(
+                user=from_user, project=project, token=from_user_token
+            ),
         )
 
 

--- a/dds_web/security/tokens.py
+++ b/dds_web/security/tokens.py
@@ -57,7 +57,7 @@ def update_token_with_mfa(token_claims):
     )
     return encrypted_jwt_token(
         username=token_claims.get("sub"),
-        sensitive_content=None,
+        sensitive_content=token_claims.get("sen_con"),
         expires_in=expires_in,
         additional_claims={"mfa_auth_time": dds_web.utils.current_time().timestamp()},
     )

--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -15,7 +15,6 @@ from dds_web.api import db_tools
 import flask_login
 import itsdangerous
 import sqlalchemy
-import marshmallow
 
 # Own Modules
 from dds_web import forms
@@ -27,7 +26,7 @@ from dds_web.api.dds_decorators import logging_bind_request
 from dds_web.api.schemas import user_schemas
 import dds_web.security
 from dds_web.api.user import DeleteUser
-
+from dds_web.security.project_user_keys import update_user_keys_for_password_change
 
 auth_blueprint = flask.Blueprint("auth_blueprint", __name__)
 
@@ -368,6 +367,11 @@ def change_password():
     if form.validate_on_submit():
         # Change password
         flask_login.current_user.password = form.new_password.data
+        update_user_keys_for_password_change(
+            user=flask_login.current_user,
+            current_password=form.current_password.data,
+            new_password=form.new_password.data,
+        )
         db.session.commit()
 
         flask_login.logout_user()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 # Standard Library
 import os
-import uuid
 import unittest.mock
 import datetime
 import subprocess
@@ -33,6 +32,7 @@ from dds_web.security.project_user_keys import (
     generate_project_key_pair,
     share_project_private_key,
 )
+from dds_web.security.tokens import encrypted_jwt_token
 
 mysql_root_password = os.getenv("MYSQL_ROOT_PASSWORD")
 DATABASE_URI_BASE = f"mysql+pymysql://root:{mysql_root_password}@db/DeliverySystemTestBase"
@@ -60,9 +60,33 @@ def fill_basic_db(db):
 
     db.session.commit()
 
-    share_project_private_key(users[2], users[0], projects[0])
-    share_project_private_key(users[2], users[1], projects[0])
-    share_project_private_key(users[3], users[6], projects[3])
+    user2_token = encrypted_jwt_token(
+        username=users[2].username,
+        sensitive_content="password",
+    )
+    share_project_private_key(
+        from_user=users[2],
+        to_another=users[0],
+        from_user_token=user2_token,
+        project=projects[0],
+    )
+    share_project_private_key(
+        from_user=users[2],
+        to_another=users[1],
+        from_user_token=user2_token,
+        project=projects[0],
+    )
+
+    user3_token = encrypted_jwt_token(
+        username=users[3].username,
+        sensitive_content="password",
+    )
+    share_project_private_key(
+        from_user=users[3],
+        to_another=users[6],
+        from_user_token=user3_token,
+        project=projects[3],
+    )
 
     db.session.commit()
 

--- a/tests/test_basic_api.py
+++ b/tests/test_basic_api.py
@@ -1,13 +1,11 @@
 # IMPORTS ################################################################################ IMPORTS #
 
 # Standard library
-from cryptography.hazmat.primitives.twofactor.hotp import HOTP
 import flask
 import http
 import datetime
 
 # Installed
-from jwcrypto import jwk, jws
 import pytest
 
 # Own
@@ -15,6 +13,7 @@ import tests
 import dds_web
 from dds_web import db
 from dds_web.security.auth import decrypt_and_verify_token_signature
+
 
 # TESTS #################################################################################### TESTS #
 

--- a/tests/test_project_listing.py
+++ b/tests/test_project_listing.py
@@ -2,13 +2,11 @@
 
 # Standard library
 import http
-import json
 import pytest
 import marshmallow
 import unittest
 
 # Own
-from dds_web import db
 from dds_web.database import models
 import tests
 
@@ -41,6 +39,26 @@ def test_list_proj_access_granted_ls(client):
     response_json = response.json
     list_of_projects = response_json.get("project_info")
     assert "public_project_id" == list_of_projects[0].get("Project ID")
+
+
+def test_proj_private_successful(client):
+    """Successfully get the private key"""
+
+    token = tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client)
+    response = client.get(tests.DDSEndpoint.PROJ_PRIVATE, query_string=proj_query, headers=token)
+    assert response.status_code == http.HTTPStatus.OK
+    response_json = response.json
+    assert response_json.get("private")
+
+
+def test_proj_private_without_project(client):
+    """Attempting to get the private key without specifying a project"""
+
+    token = tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client)
+    with pytest.raises(marshmallow.ValidationError) as error:
+        client.get(tests.DDSEndpoint.PROJ_PRIVATE, headers=token)
+    assert "project" in str(error.value)
+    assert "Missing data for required field." in str(error.value)
 
 
 def test_proj_public_no_token(client):

--- a/tests/test_project_user_keys.py
+++ b/tests/test_project_user_keys.py
@@ -207,16 +207,16 @@ def test_user_key_not_found_error_for_project(client):
 
 def test_user_key_generation(client):
     user = models.User(username="testuser", password="password")
-    assert user.public_key is not None
+    assert user.public_key
     assert isinstance(serialization.load_der_public_key(user.public_key), RSAPublicKey)
-    assert user.nonce is not None
-    assert user.private_key is not None
+    assert user.nonce
+    assert user.private_key
 
 
 def test_project_key_generation(client):
     # Setup is done in conftest.py
     project = models.Project.query.filter_by(public_id="public_project_id").first()
-    assert project.public_key is not None
+    assert project.public_key
     assert isinstance(X25519PublicKey.from_public_bytes(project.public_key), X25519PublicKey)
     number_of_unitusers_with_project_key = 0
     project_user_keys = project.project_user_keys
@@ -229,8 +229,8 @@ def test_project_key_generation(client):
             number_of_unitusers_with_project_key += 1
     assert number_of_unitusers_with_project_key == 3
     user = project_user_keys[0].user
-    assert user.nonce is not None
-    assert user.private_key is not None
+    assert user.nonce
+    assert user.private_key
 
 
 def test_project_key_sharing(client):
@@ -240,17 +240,17 @@ def test_project_key_sharing(client):
     project_researchuser_key = models.ProjectUserKeys.query.filter_by(
         project_id=project.id, user_id=researchuser.username
     ).first()
-    assert project_researchuser_key is not None
-    assert researchuser.nonce is not None
-    assert researchuser.private_key is not None
+    assert project_researchuser_key
+    assert researchuser.nonce
+    assert researchuser.private_key
 
     unituser = models.User.query.filter_by(username="unituser").first()
     project_unituser_key = models.ProjectUserKeys.query.filter_by(
         project_id=project.id, user_id=unituser.username
     ).first()
-    assert project_unituser_key is not None
-    assert unituser.nonce is not None
-    assert unituser.private_key is not None
+    assert project_unituser_key
+    assert unituser.nonce
+    assert unituser.private_key
 
 
 def test_delete_user_deletes_project_user_keys(client):
@@ -420,10 +420,10 @@ def test_update_user_keys_for_password_change(client):
     private_key_initial = user.private_key
     kd_salt_initial = user.kd_salt
 
-    assert public_key_initial is not None
-    assert nonce_initial is not None
-    assert private_key_initial is not None
-    assert kd_salt_initial is not None
+    assert public_key_initial
+    assert nonce_initial
+    assert private_key_initial
+    assert kd_salt_initial
 
     update_user_keys_for_password_change(user, "password", "bogus")
     user.password = "bogus"
@@ -433,10 +433,10 @@ def test_update_user_keys_for_password_change(client):
     private_key_after_password_change = user.private_key
     kd_salt_after_password_change = user.kd_salt
 
-    assert public_key_after_password_change is not None
-    assert nonce_after_password_change is not None
-    assert private_key_after_password_change is not None
-    assert kd_salt_after_password_change is not None
+    assert public_key_after_password_change
+    assert nonce_after_password_change
+    assert private_key_after_password_change
+    assert kd_salt_after_password_change
 
     assert public_key_after_password_change == public_key_initial
     assert nonce_after_password_change != nonce_initial
@@ -454,10 +454,10 @@ def test_update_user_keys_for_password_change(client):
     private_key_final = user.private_key
     kd_salt_final = user.kd_salt
 
-    assert public_key_final is not None
-    assert nonce_final is not None
-    assert private_key_final is not None
-    assert kd_salt_final is not None
+    assert public_key_final
+    assert nonce_final
+    assert private_key_final
+    assert kd_salt_final
 
     assert public_key_final == public_key_initial
     assert nonce_final != nonce_initial

--- a/tests/test_user_invite_no_project.py
+++ b/tests/test_user_invite_no_project.py
@@ -165,7 +165,6 @@ def test_successful_registration(registry_form_data, client):
 
     user = models.User.query.filter_by(username=registry_form_data["username"]).one_or_none()
     assert user is not None
-    assert user.temporary_key is not None
     assert user.nonce is not None
     assert user.public_key is not None
     assert user.private_key is not None


### PR DESCRIPTION
Change the way an invite token is verified and transferred to a user, Make it possible to get hold of the current encrypted token and its contents at the endpoints and the key operations, Introduce new errors for exceptional situations regarding token and keys, Remove temporary_key from user model, Derive user key from users password, Generate user key pair using the derived user key, Include sensitive content in the encrypted token, Update development and test db setup accordingly, Update some existing tests accordingly, Clean up some unused imports and Fix minor syntax issues encountered

Closes #738 