### PR TITLE
Catch exceptions for invalid token

### DIFF
--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -301,9 +301,9 @@ def decrypt_token(token):
     # Decrypt token
     try:
         decrypted_token = jwt.JWT(key=key, jwt=token)
-    except ValueError:
+    except ValueError as exc:
         # "Token format unrecognized"
-        raise AuthenticationError(message="Invalid token")
+        raise AuthenticationError(message="Invalid token") from exc
 
     return decrypted_token.claims
 
@@ -324,9 +324,9 @@ def verify_token_signature(token):
         # jwt dependency uses a 60 seconds leeway to check exp
         # it also prints out a stack trace for it, so we handle it here
         raise AuthenticationError(message="Expired token")
-    except ValueError:
+    except ValueError as exc:
         # "Token format unrecognized"
-        raise AuthenticationError(message="Invalid token")
+        raise AuthenticationError(message="Invalid token") from exc
 
 
 @basic_auth.verify_password

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -299,7 +299,12 @@ def decrypt_token(token):
     # Get key used for encryption
     key = jwk.JWK.from_password(flask.current_app.config.get("SECRET_KEY"))
     # Decrypt token
-    decrypted_token = jwt.JWT(key=key, jwt=token)
+    try:
+        decrypted_token = jwt.JWT(key=key, jwt=token)
+    except ValueError:
+        # "Token format unrecognized"
+        raise AuthenticationError(message="Invalid token")
+
     return decrypted_token.claims
 
 
@@ -319,6 +324,9 @@ def verify_token_signature(token):
         # jwt dependency uses a 60 seconds leeway to check exp
         # it also prints out a stack trace for it, so we handle it here
         raise AuthenticationError(message="Expired token")
+    except ValueError:
+        # "Token format unrecognized"
+        raise AuthenticationError(message="Invalid token")
 
 
 @basic_auth.verify_password


### PR DESCRIPTION
Before submitting a pr:
- [X] Tests passing
- [X] Black formatting
- [X] Rebase/merge the `dev` branch

Catch two `ValueError` exceptions when receiving bad/empty tokens. Could be that I should catch them somewhere else.

Removes logs like the following:
```
Traceback (most recent call last):
  File "/code/dds_web/security/auth.py", line 216, in __verify_general_token
    else decrypt_and_verify_token_signature(token=token)
  File "/code/dds_web/security/auth.py", line 291, in decrypt_and_verify_token_signature
    return verify_token_signature(token=decrypt_token(token=token))
  File "/code/dds_web/security/auth.py", line 302, in decrypt_token
    decrypted_token = jwt.JWT(key=key, jwt=token)
  File "/usr/local/lib/python3.10/site-packages/jwcrypto/jwt.py", line 204, in __init__
    self.deserialize(jwt, key)
  File "/usr/local/lib/python3.10/site-packages/jwcrypto/jwt.py", line 481, in deserialize
    raise ValueError("Token format unrecognized")
ValueError: Token format unrecognized
```
Which shows up when requesting:
```
curl -X POST localhost:5000/reset_password/asdasd
```
