### PR TITLE
Issue924 no mail flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 
 ## Sprint (2022-02-23 - 2022-03-09)
 * Add landing page after password reset ([931](https://github.com/ScilifelabDataCentre/dds_web/pull/931))
+* Introduced a `--no-mail` flag in the CLI respectively a `send_email: True/False` json parameter to fix [issue 924](https://github.com/scilifelabdatacentre/dds_web/issues/924) ([#925](https://github.com/ScilifelabDataCentre/dds_web/pull/925))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 
 ## Sprint (2022-02-23 - 2022-03-09)
 * Add landing page after password reset ([931](https://github.com/ScilifelabDataCentre/dds_web/pull/931))
-* Introduced a `--no-mail` flag in the CLI respectively a `send_email: True/False` json parameter to fix [issue 924](https://github.com/scilifelabdatacentre/dds_web/issues/924) ([#925](https://github.com/ScilifelabDataCentre/dds_web/pull/925))
+* Introduced a `--no-mail` flag in the CLI respectively a `send_email: True/False` json parameter to fix [issue 924](https://github.com/scilifelabdatacentre/dds_web/issues/924) ([#926](https://github.com/ScilifelabDataCentre/dds_web/pull/926))

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -93,7 +93,7 @@ class ProjectStatus(flask_restful.Resource):
         ]:
             raise DDSArgumentError("Invalid status")
 
-        send_email = extra_args.get("send_email", True)
+        send_email = json_input.get("send_email", True)
 
         curr_date = dds_web.utils.current_time()
         is_aborted = False

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -93,6 +93,8 @@ class ProjectStatus(flask_restful.Resource):
         ]:
             raise DDSArgumentError("Invalid status")
 
+        send_email = extra_args.get("send_email", True)
+
         curr_date = dds_web.utils.current_time()
         is_aborted = False
         add_deadline = None
@@ -177,13 +179,17 @@ class ProjectStatus(flask_restful.Resource):
             raise DatabaseError(message="Server Error: Status was not updated")
 
         # Mail users once project is made available
-        if new_status == "Available":
+        if new_status == "Available" and send_email:
             for user in project.researchusers:
                 AddUser.compose_and_send_email_to_user(
                     userobj=user.researchuser, mail_type="project_release", project=project
                 )
 
-        return {"message": f"{project.public_id} updated to status {new_status}" + delete_message}
+        return {
+            "message": f"{project.public_id} updated to status {new_status}"
+            + delete_message
+            + f". An e-mail notification has{' not ' if not send_email else ' '}been sent."
+        }
 
     def is_transition_possible(self, current_status, new_status):
         """Check if the transition is valid"""

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -205,7 +205,7 @@ class AddUser(flask_restful.Resource):
                             project=unit_project,
                         )
 
-                if project:  # specified project is disregarded for unituser invites
+                if not project:  # specified project is disregarded for unituser invites
                     msg = f"{str(new_invite)} was successful."
                 else:
                     msg = f"{str(new_invite)} was successful, but specification for {str(project)} dropped. Unit Users have automatic access to projects of their unit."

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -71,7 +71,10 @@ class AddUser(flask_restful.Resource):
         # Verify email
         email = json_info.get("email")
         if not email:
-            raise ddserr.DDSArgumentError(message="Email adress required to add or invite.")
+            raise ddserr.DDSArgumentError(message="Email address required to add or invite.")
+
+        # Notify the users about project additions? Invites are still being sent out.
+        send_email = json_info.get("send_email", True)
 
         # Check if email is registered to a user
         existing_user = user_schemas.UserSchema().load({"email": email})
@@ -87,7 +90,10 @@ class AddUser(flask_restful.Resource):
                 )
 
             add_user_result = self.add_to_project(
-                whom=existing_user or unanswered_invite, project=project, role=role
+                whom=existing_user or unanswered_invite,
+                project=project,
+                role=role,
+                send_email=send_email,
             )
             return add_user_result, add_user_result["status"]
 
@@ -240,7 +246,7 @@ class AddUser(flask_restful.Resource):
 
     @staticmethod
     @logging_bind_request
-    def add_to_project(whom, project, role):
+    def add_to_project(whom, project, role, send_email=True):
         """Add existing user or invite to a project"""
 
         allowed_roles = ["Project Owner", "Researcher"]
@@ -256,7 +262,6 @@ class AddUser(flask_restful.Resource):
 
         owner = role == "Project Owner"
         ownership_change = False
-        send_email = True
 
         if isinstance(whom, models.ResearchUser):
             project_user_row = models.ProjectUsers.query.filter_by(
@@ -314,7 +319,10 @@ class AddUser(flask_restful.Resource):
 
         return {
             "status": http.HTTPStatus.OK,
-            "message": (f"{str(whom)} was associated with " f"{str(project)} as Owner={owner}."),
+            "message": (
+                f"{str(whom)} was associated with "
+                f"{str(project)} as Owner={owner}. An e-mail notification has{' not ' if not send_email else ' '}been sent."
+            ),
         }
 
     @staticmethod

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -367,7 +367,7 @@ def test_set_project_to_available_valid_transition(module_client, test_project):
     assert db_deadline == calc_deadline
 
 
-def test_set_project_to_available_no_mail(client):
+def test_set_project_to_available_no_mail(client, boto3_session):
     """Set status to Available for test project, but skip sending mails"""
 
     response = client.post(
@@ -393,8 +393,8 @@ def test_set_project_to_available_no_mail(client):
                 json={"new_status": "Available", "deadline": 10, "send_email": False},
             )
         # assert that no mail is being sent.
-        assert mock_mail_send.call_count == 0
         assert mock_mail_func.called == False
+        assert mock_mail_send.call_count == 0
 
     assert response.status_code == http.HTTPStatus.OK
     assert "An e-mail notification has not been sent." in response.json["message"]

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -367,12 +367,12 @@ def test_set_project_to_available_valid_transition(module_client, test_project):
     assert db_deadline == calc_deadline
 
 
-def test_set_project_to_available_no_mail(client, boto3_session):
+def test_set_project_to_available_no_mail(module_client, boto3_session):
     """Set status to Available for test project, but skip sending mails"""
 
-    token = tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client)
+    token = tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(module_client)
 
-    response = client.post(
+    response = module_client.post(
         tests.DDSEndpoint.PROJECT_CREATE,
         headers=token,
         json=proj_data_with_existing_users,
@@ -388,7 +388,7 @@ def test_set_project_to_available_no_mail(client, boto3_session):
         with unittest.mock.patch.object(
             dds_web.api.user.AddUser, "compose_and_send_email_to_user"
         ) as mock_mail_func:
-            response = client.post(
+            response = module_client.post(
                 tests.DDSEndpoint.PROJECT_STATUS,
                 headers=token,
                 query_string={"project": public_project_id},

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -13,8 +13,10 @@ import boto3
 import flask_mail
 
 # Own
+import dds_web
 import tests
 from tests.test_files_new import project_row, file_in_db, FIRST_NEW_FILE
+from tests.test_project_creation import proj_data_with_existing_users
 
 # CONFIG ################################################################################## CONFIG #
 
@@ -363,6 +365,39 @@ def test_set_project_to_available_valid_transition(module_client, test_project):
     ) + datetime.timedelta(days=new_status["deadline"])
 
     assert db_deadline == calc_deadline
+
+
+def test_set_project_to_available_no_mail(client):
+    """Set status to Available for test project, but skip sending mails"""
+
+    response = client.post(
+        tests.DDSEndpoint.PROJECT_CREATE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
+        json=proj_data_with_existing_users,
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    assert response.json and response.json.get("user_addition_statuses")
+    for x in response.json.get("user_addition_statuses"):
+        assert "associated with Project" in x
+
+    public_project_id = response.json.get("project_id")
+
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+        with unittest.mock.patch.object(
+            dds_web.api.user.AddUser, "compose_and_send_email_to_user"
+        ) as mock_mail_func:
+            response = client.post(
+                tests.DDSEndpoint.PROJECT_STATUS,
+                headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
+                query_string={"project": public_project_id},
+                json={"new_status": "Available", "deadline": 10, "send_email": False},
+            )
+        # assert that no mail is being sent.
+        assert mock_mail_send.call_count == 0
+        assert mock_mail_func.called == False
+
+    assert response.status_code == http.HTTPStatus.OK
+    assert "An e-mail notification has not been sent." in response.json["message"]
 
 
 def test_set_project_to_deleted_from_available(module_client, test_project):

--- a/tests/test_project_status.py
+++ b/tests/test_project_status.py
@@ -370,9 +370,11 @@ def test_set_project_to_available_valid_transition(module_client, test_project):
 def test_set_project_to_available_no_mail(client, boto3_session):
     """Set status to Available for test project, but skip sending mails"""
 
+    token = tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client)
+
     response = client.post(
         tests.DDSEndpoint.PROJECT_CREATE,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
+        headers=token,
         json=proj_data_with_existing_users,
     )
     assert response.status_code == http.HTTPStatus.OK
@@ -388,12 +390,12 @@ def test_set_project_to_available_no_mail(client, boto3_session):
         ) as mock_mail_func:
             response = client.post(
                 tests.DDSEndpoint.PROJECT_STATUS,
-                headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
+                headers=token,
                 query_string={"project": public_project_id},
                 json={"new_status": "Available", "deadline": 10, "send_email": False},
             )
-        # assert that no mail is being sent.
-        assert mock_mail_func.called == False
+            # assert that no mail is being sent.
+            assert mock_mail_func.called == False
         assert mock_mail_send.call_count == 0
 
     assert response.status_code == http.HTTPStatus.OK

--- a/tests/test_user_add.py
+++ b/tests/test_user_add.py
@@ -365,7 +365,7 @@ def test_add_existing_user_to_existing_project(client):
     assert project_user_after_addition
 
 
-def test_add_existing_user_to_existing_project_no_mail_flag(client, boto3_session):
+def test_add_existing_user_to_existing_project_no_mail_flag(client):
     "Test that an e-mail notification is not send when the --no-mail flag is used"
 
     user_copy = existing_research_user_to_existing_project.copy()

--- a/tests/test_user_add.py
+++ b/tests/test_user_add.py
@@ -365,7 +365,7 @@ def test_add_existing_user_to_existing_project(client):
     assert project_user_after_addition
 
 
-def test_add_existing_user_to_existing_project_no_mail_flag(client):
+def test_add_existing_user_to_existing_project_no_mail_flag(client, boto3_session):
     "Test that an e-mail notification is not send when the --no-mail flag is used"
 
     user_copy = existing_research_user_to_existing_project.copy()

--- a/tests/test_user_add.py
+++ b/tests/test_user_add.py
@@ -1,3 +1,4 @@
+import dds_web
 import flask_mail
 import http
 import json
@@ -362,6 +363,46 @@ def test_add_existing_user_to_existing_project(client):
         )
     ).one_or_none()
     assert project_user_after_addition
+
+
+def test_add_existing_user_to_existing_project_no_mail_flag(client):
+    "Test that an e-mail notification is not send when the --no-mail flag is used"
+
+    user_copy = existing_research_user_to_existing_project.copy()
+    project_id = user_copy.pop("project")
+    new_status = {"new_status": "Available"}
+    user_copy["send_email"] = False
+    token = tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client)
+
+    # make project available prior to test, otherwise an e-mail is never sent.
+    response = client.post(
+        tests.DDSEndpoint.PROJECT_STATUS,
+        headers=token,
+        query_string={"project": project_id},
+        data=json.dumps(new_status),
+        content_type="application/json",
+    )
+
+    # Test mail sending is suppressed
+
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+        with unittest.mock.patch.object(
+            dds_web.api.user.AddUser, "compose_and_send_email_to_user"
+        ) as mock_mail_func:
+            print(user_copy)
+            response = client.post(
+                tests.DDSEndpoint.USER_ADD,
+                headers=token,
+                query_string={"project": project_id},
+                data=json.dumps(user_copy),
+                content_type="application/json",
+            )
+        # assert that no mail is being sent: One call is due to 2FA
+        assert mock_mail_send.call_count == 1
+        assert mock_mail_func.called == False
+
+    assert response.status_code == http.HTTPStatus.OK
+    assert "An e-mail notification has not been sent." in response.json["message"]
 
 
 def test_add_existing_user_to_existing_project_after_release(client):

--- a/tests/test_user_add.py
+++ b/tests/test_user_add.py
@@ -397,8 +397,8 @@ def test_add_existing_user_to_existing_project_no_mail_flag(client):
                 data=json.dumps(user_copy),
                 content_type="application/json",
             )
-        # assert that no mail is being sent: One call is due to 2FA
-        assert mock_mail_send.call_count == 1
+        # assert that no mail is being sent.
+        assert mock_mail_send.call_count == 0
         assert mock_mail_func.called == False
 
     assert response.status_code == http.HTTPStatus.OK

--- a/tests/test_user_add.py
+++ b/tests/test_user_add.py
@@ -397,9 +397,9 @@ def test_add_existing_user_to_existing_project_no_mail_flag(client):
                 data=json.dumps(user_copy),
                 content_type="application/json",
             )
-        # assert that no mail is being sent.
-        assert mock_mail_send.call_count == 0
-        assert mock_mail_func.called == False
+            # assert that no mail is being sent.
+            assert mock_mail_func.called == False
+    assert mock_mail_send.call_count == 0
 
     assert response.status_code == http.HTTPStatus.OK
     assert "An e-mail notification has not been sent." in response.json["message"]


### PR DESCRIPTION
Before submitting a pr:
- [x] Tests passing
- [x] Black formatting
- [ ] Migrations for any changes to the database schema
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

Introduced a `--no-mail` flag in the CLI respectively a `send_email: True/False` json parameter to fix [issue 924](https://github.com/scilifelabdatacentre/dds_web/issues/924) ([#925](https://github.com/ScilifelabDataCentre/dds_web/pull/925))
