### PR TITLE
Change regex to raw string 

### DIFF
--- a/dds_web/api/files.py
+++ b/dds_web/api/files.py
@@ -498,7 +498,7 @@ class RemoveDir(flask_restful.Resource):
                 .filter(
                     sqlalchemy.or_(
                         models.File.subpath == sqlalchemy.func.binary(folder),
-                        models.File.subpath.op("regexp")(f"^{folder}(\/[^\/]+)*$"),
+                        models.File.subpath.regexp_match(rf"^{folder}(/[^/]+)*$"),
                     )
                 )
                 .all()


### PR DESCRIPTION
Minor change to use regexp_match to make it db independent and use a raw string to get rid of a deprecation warning.

- [X] Tests passing
- [X] Black formatting
- [ ] Migrations for any changes to the database schema
- [X] Rebase/merge the `dev` branch
- [ ] Note in the CHANGELOG

