### PR TITLE
Remove intro text, add newlines in pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
-Before submitting a pr:
+
+
 - [ ] Tests passing
 - [ ] Black formatting
 - [ ] Migrations for any changes to the database schema


### PR DESCRIPTION
Update the template to remove the "Before submitting a pr:" text and add some whitespace on top of the checklist.

- [x] Tests passing
- [x] Black formatting
- [ ] Migrations for any changes to the database schema
- [ ] Rebase/merge the `dev` branch
- [ ] Note in the CHANGELOG

