### PR TITLE
Action log entry for uncaught exceptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * Invite Unit Admin (temporary way) ([#938](https://github.com/ScilifelabDataCentre/dds_web/pull/938))
 * Add support for getting IPs from X-Forwarded-For ([#952](https://github.com/ScilifelabDataCentre/dds_web/pull/952))
 * Relax requirements for usernames (wider length range, `.` and `-`) ([#943](https://github.com/ScilifelabDataCentre/dds_web/pull/943))
+* Extended the `dds_web.api.dds_decorators.logging_bind_request` decorator to catch all not yet caught exceptions and make sure they will be logged ([#958](https://github.com/ScilifelabDataCentre/dds_web/pull/958)).

--- a/dds_web/api/dds_decorators.py
+++ b/dds_web/api/dds_decorators.py
@@ -6,8 +6,6 @@
 
 # Standard library
 import functools
-import sys
-import traceback
 
 # Installed
 import boto3

--- a/dds_web/api/dds_decorators.py
+++ b/dds_web/api/dds_decorators.py
@@ -172,5 +172,6 @@ def logging_bind_request(func):
                     f"Uncaught exception in {flask.request.endpoint}.{func.__name__}",
                     stack_info=False,
                 )
+                raise
 
     return wrapper_logging_bind_request

--- a/dds_web/api/dds_decorators.py
+++ b/dds_web/api/dds_decorators.py
@@ -155,7 +155,13 @@ def logging_bind_request(func):
             project=flask.request.args.get("project") if flask.request.args else None,
             user=get_username_or_request_ip(),
         ):
-            value = func(*args, **kwargs)
+
+            try:
+                value = func(*args, **kwargs)
+            except Exception as err:
+                structlog.threadlocal.bind_threadlocal(exception=err)
+                action_logger.error("DDS encountered an uncaught exception!", stack_info=True)
+                raise
 
             if hasattr(value, "status"):
                 structlog.threadlocal.bind_threadlocal(response=value.status)


### PR DESCRIPTION
Addresses issue  #949. After a lot of trial and error with manual error and Traceback/StackSummary formatting, I went with the default formatting provided by `structlog`. 

The log entry for an uncaught exception will look like this then:
```

{"resource": "/api/v1/proj/list", "project": null, "user": "unituser_1", "exception": "Traceback (most recent call last):\n  File \"/code/dds_web/api/dds_decorators.py\", line 162, in wrapper_logging_bind_request\n    value = func(*args, **kwargs)\n  File \"/code/dds_web/api/project.py\", line 289, in get\n    total_bhours_db = 1 / 0.0\nZeroDivisionError: float division by zero", "event": "Uncaught exception in api_blueprint.list_projects.get", "logger": "actions", "level": "error", "timestamp": "2022-02-28T16:24:20.761019Z"}
```

It is now only an addition to the decorator, thus misses out on all non-decorated endpoints (only a few though). On [Stack Overflow](https://stackoverflow.com/questions/8050775/using-pythons-logging-module-to-log-all-exceptions-and-errors/68293938#68293938) I also found a demo to wrap the system’s except hook - this would be an alternative approach. Any opinions on that?

- [x] Tests passing
- [x] Black formatting
- [ ] Migrations for any changes to the database schema
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

