### PR TITLE
Move project creation commit from schema to the api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * Invite Unit Admin (temporary way) ([#938](https://github.com/ScilifelabDataCentre/dds_web/pull/938))
 * Add support for getting IPs from X-Forwarded-For ([#952](https://github.com/ScilifelabDataCentre/dds_web/pull/952))
 * Relax requirements for usernames (wider length range, `.` and `-`) ([#943](https://github.com/ScilifelabDataCentre/dds_web/pull/943))
+* Delay committing project to db until after the bucket has been created ([#967](https://github.com/ScilifelabDataCentre/dds_web/pull/967))

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -12,6 +12,7 @@ import flask
 import sqlalchemy
 import datetime
 import botocore
+import marshmallow
 
 # Own modules
 import dds_web.utils
@@ -450,11 +451,11 @@ class CreateProject(flask_restful.Resource):
         except (sqlalchemy.exc.SQLAlchemyError, TypeError) as err:
             flask.current_app.logger.exception(err)
             db.session.rollback()
-            raise ddserr.DatabaseError(message="Server Error: Project was not created") from err
+            raise DatabaseError(message="Server Error: Project was not created") from err
         except (
             marshmallow.ValidationError,
-            ddserr.DDSArgumentError,
-            ddserr.AccessDeniedError,
+            DDSArgumentError,
+            AccessDeniedError,
         ) as err:
             flask.current_app.logger.exception(err)
             db.session.rollback()

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -442,7 +442,10 @@ class CreateProject(flask_restful.Resource):
         with ApiS3Connector(project=new_project) as s3:
             try:
                 s3.resource.create_bucket(Bucket=new_project.bucket)
-            except botocore.exceptions.ClientError as err:
+            except (
+                botocore.exceptions.ClientError,
+                botocore.exceptions.ParamValidationError,
+            ) as err:
                 # For now just keeping the project row
                 raise S3ConnectionError(str(err))
 

--- a/dds_web/api/schemas/project_schemas.py
+++ b/dds_web/api/schemas/project_schemas.py
@@ -131,56 +131,37 @@ class CreateProjectSchema(marshmallow.Schema):
     def create_project(self, data, **kwargs):
         """Create project row in db."""
 
-        try:
-            # Lock db, get unit row and update counter
-            unit_row = (
-                models.Unit.query.filter_by(id=auth.current_user().unit_id)
-                .with_for_update()
-                .one_or_none()
+        # Lock db, get unit row and update counter
+        unit_row = (
+            models.Unit.query.filter_by(id=auth.current_user().unit_id)
+            .with_for_update()
+            .one_or_none()
+        )
+        if not unit_row:
+            raise ddserr.AccessDeniedError(message=f"Error: Your user is not associated to a unit.")
+
+        unit_row.counter = unit_row.counter + 1 if unit_row.counter else 1
+        data["public_id"] = "{}{:05d}".format(unit_row.internal_ref, unit_row.counter)
+
+        # Generate bucket name
+        data["bucket"] = self.generate_bucketname(
+            public_id=data["public_id"], created_time=data["date_created"]
+        )
+
+        # Create project
+        current_user = auth.current_user()
+        new_project = models.Project(
+            **{**data, "unit_id": current_user.unit.id, "created_by": current_user.username}
+        )
+        new_project.project_statuses.append(
+            models.ProjectStatuses(
+                **{
+                    "status": "In Progress",
+                    "date_created": data["date_created"],
+                }
             )
-            if not unit_row:
-                raise ddserr.AccessDeniedError(
-                    message=f"Error: Your user is not associated to a unit."
-                )
-
-            unit_row.counter = unit_row.counter + 1 if unit_row.counter else 1
-            data["public_id"] = "{}{:05d}".format(unit_row.internal_ref, unit_row.counter)
-
-            # Generate bucket name
-            data["bucket"] = self.generate_bucketname(
-                public_id=data["public_id"], created_time=data["date_created"]
-            )
-
-            # Create project
-            current_user = auth.current_user()
-            new_project = models.Project(
-                **{**data, "unit_id": current_user.unit.id, "created_by": current_user.username}
-            )
-            new_project.project_statuses.append(
-                models.ProjectStatuses(
-                    **{
-                        "status": "In Progress",
-                        "date_created": data["date_created"],
-                    }
-                )
-            )
-
-            generate_project_key_pair(current_user, new_project)
-
-            db.session.add(new_project)
-            db.session.commit()
-        except (sqlalchemy.exc.SQLAlchemyError, TypeError) as err:
-            flask.current_app.logger.exception(err)
-            db.session.rollback()
-            raise ddserr.DatabaseError(message="Server Error: Project was not created")
-        except (
-            marshmallow.ValidationError,
-            ddserr.DDSArgumentError,
-            ddserr.AccessDeniedError,
-        ) as err:
-            flask.current_app.logger.exception(err)
-            db.session.rollback()
-            raise
+        )
+        generate_project_key_pair(current_user, new_project)
 
         return new_project
 


### PR DESCRIPTION
Move project creation commit out of the schema to the API endpoint to avoid having a project without bucket if the bucket creation fails.

Fixes #964 

- [X] Tests passing
- [X] Black formatting
- [-] Migrations for any changes to the database schema
- [X] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

