### PR TITLE
Print the login HOTP key to the log if in dev mode

### DIFF
--- a/dds_web/utils.py
+++ b/dds_web/utils.py
@@ -344,6 +344,10 @@ def create_one_time_password_email(user, hotp_value):
             ["Content-ID", "<Logo>"],
         ],
     )
+    if flask.current_app.env == "development":
+        flask.current_app.logger.info(
+            f"HOTP value for {user.username}: {hotp_value.decode('utf-8')}"
+        )
     msg.body = flask.render_template(
         "mail/authenticate.txt", one_time_value=hotp_value.decode("utf-8")
     )


### PR DESCRIPTION
Simplify development (no email needed) by simply printing the HOTP value in the web log when `FLASK_ENV=development`.

- [X] Tests passing
- [X] Black formatting
- [-] Migrations for any changes to the database schema
- [X] Rebase/merge the `dev` branch
- [-] Note in the CHANGELOG

