### PR TITLE
Use minio for s3 storage in dev

### DIFF
--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -31,10 +31,10 @@ class Config(object):
     # Expected paths - these are the bind paths *inside* the container
     USE_LOCAL_DB = True
     LOGS_DIR = "/dds_web/logs"
-    SAFESPRING_URL = os.environ.get("DDS_SAFESPRING_URL", "https://example.endpoint.net")
+    SAFESPRING_URL = os.environ.get("DDS_SAFESPRING_URL", "http://minio:9000")
     DDS_SAFESPRING_PROJECT = os.environ.get("DDS_SAFESPRING_PROJECT", "project-name.example.se")
-    DDS_SAFESPRING_ACCESS = os.environ.get("DDS_SAFESPRING_ACCESS", "SAFESPRINGACCESSKEY")
-    DDS_SAFESPRING_SECRET = os.environ.get("DDS_SAFESPRING_SECRET", "SAFESPRINGSECRETKEY")
+    DDS_SAFESPRING_ACCESS = os.environ.get("DDS_SAFESPRING_ACCESS", "minio")
+    DDS_SAFESPRING_SECRET = os.environ.get("DDS_SAFESPRING_SECRET", "minioPassword")
 
     # Use short-lived session cookies:
     PERMANENT_SESSION_LIFETIME = datetime.timedelta(hours=1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,21 @@ services:
         source: $DDS_LOG_DIR
         target: /dds_web/logs
 
+  minio:
+    image: minio/minio:RELEASE.2022-02-24T22-12-01Z
+    command: server /data --console-address ":9001"
+    ports:
+      - 127.0.0.1:9000:9000
+      - 127.0.0.1:9001:9001
+    environment:
+      MINIO_ROOT_USER: minio  # access key
+      MINIO_ROOT_PASSWORD: minioPassword  # secret key
+    # volumes:
+    #   - type: bind
+    #     source: ./minio-data
+    #     target: /data
+
+
 #  redis:
 #    container_name: dds_redis
 #    image: redis:latest


### PR DESCRIPTION
Use minio for s3 storage during development
* Adds a minio container for docker-compose
* Updates the default values in `config.py` to enable a no-conf dev environment

- [X] Tests passing
- [X] Black formatting
- [-] Migrations for any changes to the database schema
- [X] Rebase/merge the `dev` branch
- [-] Note in the CHANGELOG

