### PR TITLE
Add check for if superadmin for delete email

### DIFF
--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -451,7 +451,9 @@ class DeleteUserSelf(flask_restful.Resource):
 
         username = current_user.username
 
-        proj_ids = [proj.public_id for proj in current_user.projects]
+        proj_ids = None
+        if current_user.role != "Super Admin":
+            proj_ids = [proj.public_id for proj in current_user.projects]
 
         # Create URL safe token for invitation link
         s = itsdangerous.URLSafeTimedSerializer(flask.current_app.config["SECRET_KEY"])


### PR DESCRIPTION
When using `dd user delete --self` as a super admin, the email sent out contained all projects within the system. 

- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [x] Rebase/merge the `dev` branch
- [ - ] Note in the CHANGELOG

