### PR TITLE
Simplify setting up dev environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 * Add role when listing project users ([#974](https://github.com/ScilifelabDataCentre/dds_web/pull/974))
 * Add custom error messages to registration form ([#975](https://github.com/ScilifelabDataCentre/dds_web/pull/975))
 * Fix format of self deletion email ([#984](https://github.com/ScilifelabDataCentre/dds_web/pull/984))
+* Add a full zero-conf development environment ([#993](https://github.com/ScilifelabDataCentre/dds_web/pull/993))

--- a/Dockerfiles/cli.Dockerfile
+++ b/Dockerfiles/cli.Dockerfile
@@ -1,0 +1,13 @@
+FROM python:latest as base
+
+RUN apt-get update && apt-get upgrade -y && apt-get install git
+RUN git clone https://github.com/ScilifelabDataCentre/dds_cli /code
+WORKDIR /code
+
+# Install all dependencies
+RUN pip3 install -r /code/requirements.txt
+
+# Add code directory in pythonpath
+ENV PYTHONPATH /code
+
+CMD ["tail", "-f", "/dev/null"] # to keep container running

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ If you prefer, you can run the web servers in 'detached' mode with the `-d` flag
 If using this method, you can stop the web server with the command `docker-compose down`.
 <br><br>
 
+#### CLI development against local environment
+
+```bash
+docker-compose --profile cli up
+```
+Will start database, backend, minio, and mailcatcher. Will also start an extra container prepared for working with the CLI.
+
+Requires that dds_cli is checked out in `../dds_cli` (otherwise adapt the volume path in `docker-compose.yml`).
+
+1. Start docker-compose with the `cli` profile
+2. Inject into the `dds_cli` container:
+
+```bash
+docker exec -it dds_cli /bin/bash
+```
+
+3. pip install -e .
+
+Then you can freely use the dds cli component against the local development setup in the active CLI.
+
 ### Python debugger inside docker
 It's possible to use the interactive debugging tool `pdb` inside Docker with this method:
 1. Edit the `docker-compose.yml` and for the `backend` service, add:

--- a/README.md
+++ b/README.md
@@ -34,12 +34,25 @@ You can download Docker here: <https://docs.docker.com/get-docker/>
 Then, fork this repository and clone to your local system.
 In the root folder of the repo, run the server as follows:
 
+There are multiple profiles prepared depending on your needs:
+
 ```bash
 docker-compose up
 ```
+This command will orchestrate the building and running of two containers: one for the SQL database (`mariadb`) and one for the application.
 
-This command will orchestrate the building and running of two containers:
-one for the SQL database (`mariadb`) and one for the application.
+```bash
+docker-compose --profile dev up
+```
+
+This will give you the above two containers, but also `minio` to enable uploads to S3 storage and `mailcatcher` that will allow you to
+read any sent emails by going to `localhost:1080` in a web browser.
+
+```bash
+docker-compose --profile full-dev up
+```
+
+Apart from the above four containers, you will also get redis to enable a persistent limiter for the API. You also need to uncomment `RATELIMIT_STORAGE_URI` in `docker-compose.yml` to enable redis.
 
 If you prefer, you can run the web servers in 'detached' mode with the `-d` flag, which does not block your terminal.
 If using this method, you can stop the web server with the command `docker-compose down`.

--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ This command will orchestrate the building and running of two containers: one fo
 docker-compose --profile dev up
 ```
 
-This will give you the above two containers, but also `minio` to enable uploads to S3 storage and `mailcatcher` that will allow you to
-read any sent emails by going to `localhost:1080` in a web browser.
+This will give you the above two containers, but also `mailcatcher` that will allow you to read
+any sent emails by going to `localhost:1080` in a web browser.
 
 ```bash
 docker-compose --profile full-dev up
 ```
 
-Apart from the above four containers, you will also get redis to enable a persistent limiter for the API. You also need to uncomment `RATELIMIT_STORAGE_URI` in `docker-compose.yml` to enable redis.
+Will also activate minio for s3 storage (clearly not functional with cli) and redis to enable a persistent limiter for the API.
+You also need to uncomment `RATELIMIT_STORAGE_URI` in `docker-compose.yml` to enable redis.
 
 If you prefer, you can run the web servers in 'detached' mode with the `-d` flag, which does not block your terminal.
 If using this method, you can stop the web server with the command `docker-compose down`.

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -31,10 +31,10 @@ class Config(object):
     # Expected paths - these are the bind paths *inside* the container
     USE_LOCAL_DB = True
     LOGS_DIR = "/dds_web/logs"
-    SAFESPRING_URL = os.environ.get("DDS_SAFESPRING_URL", "https://example.endpoint.net")
+    SAFESPRING_URL = os.environ.get("DDS_SAFESPRING_URL", "http://minio:9000")
     DDS_SAFESPRING_PROJECT = os.environ.get("DDS_SAFESPRING_PROJECT", "project-name.example.se")
-    DDS_SAFESPRING_ACCESS = os.environ.get("DDS_SAFESPRING_ACCESS", "SAFESPRINGACCESSKEY")
-    DDS_SAFESPRING_SECRET = os.environ.get("DDS_SAFESPRING_SECRET", "SAFESPRINGSECRETKEY")
+    DDS_SAFESPRING_ACCESS = os.environ.get("DDS_SAFESPRING_ACCESS", "minio")
+    DDS_SAFESPRING_SECRET = os.environ.get("DDS_SAFESPRING_SECRET", "minioPassword")
 
     # Use short-lived session cookies:
     PERMANENT_SESSION_LIFETIME = datetime.timedelta(hours=1)

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -49,11 +49,11 @@ class Config(object):
     OIDC_CLIENT_SECRET = ""
     OIDC_ACCESS_TOKEN_URL = ""
 
-    MAIL_SERVER = "smtp.mailtrap.io"
-    MAIL_PORT = 2525
-    MAIL_USERNAME = os.environ.get("MAIL_USERNAME", "mailtrap_username")
-    MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD", "mailtrap_password")
-    MAIL_USE_TLS = True
+    MAIL_SERVER = "mailcatcher"
+    MAIL_PORT = 1025
+    MAIL_USERNAME = os.environ.get("MAIL_USERNAME", "")
+    MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD", "")
+    MAIL_USE_TLS = False
     MAIL_USE_SSL = False
     MAIL_DEFAULT_SENDER = "dds@noreply.se"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,21 @@ services:
         source: $DDS_LOG_DIR
         target: /dds_web/logs
 
+  minio:
+    image: minio/minio:RELEASE.2022-02-24T22-12-01Z
+    command: server /data --console-address ":9001"
+    ports:
+      - 127.0.0.1:9000:9000
+      - 127.0.0.1:9001:9001
+    environment:
+      MINIO_ROOT_USER: minio  # access key
+      MINIO_ROOT_PASSWORD: minioPassword  # secret key
+    # volumes:
+    #   - type: bind
+    #     source: ./minio-data
+    #     target: /data
+
+
 #  redis:
 #    container_name: dds_redis
 #    image: redis:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,8 @@ services:
     environment:
       MINIO_ROOT_USER: minio  # access key
       MINIO_ROOT_PASSWORD: minioPassword  # secret key
+    # NOTE: Uncomment if you want to keep your data.
+    #             Mounts a folder into the container to make uploaded data persistent.
     # volumes:
     #   - type: bind
     #     source: ./minio-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
-version: "3.8"
+version: "3.9"
 # for persistent endpoint limiter, uncomment RATELIMIT_STORAGE_URI and the redis entry
 
 services:
-
   db:
     container_name: dds_database
     image: mariadb:latest
@@ -53,7 +52,6 @@ services:
     ports:
       - 127.0.0.1:5000:5000
     volumes:
-
       # Migrations
       - type: bind
         source: ./migrations
@@ -81,6 +79,9 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2022-02-24T22-12-01Z
+    profiles:
+      - dev
+      - full-dev
     command: server /data --console-address ":9001"
     ports:
       - 127.0.0.1:9000:9000
@@ -93,12 +94,16 @@ services:
     #     source: ./minio-data
     #     target: /data
 
-#  mailcatcher:
-#    image: sj26/mailcatcher:latest
-#    restart: on-failure
-#    ports:
-#      - 127.0.0.1:1080:1080    
+  mailcatcher:
+    image: sj26/mailcatcher:latest
+    profiles:
+      - dev
+      - full-dev
+    ports:
+      - 127.0.0.1:1080:1080    
 
-#  redis:
-#    container_name: dds_redis
-#    image: redis:latest
+  redis:
+    container_name: dds_redis
+    image: redis:latest
+    profiles:
+      - full-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,10 +78,12 @@ services:
         target: /dds_web/logs
 
   minio:
+    container_name: dds_minio
     image: minio/minio:RELEASE.2022-02-24T22-12-01Z
     profiles:
       - s3
       - full-dev
+      - cli
     command: server /data --console-address ":9001"
     ports:
       - 127.0.0.1:9000:9000
@@ -95,11 +97,13 @@ services:
     #     target: /data
 
   mailcatcher:
+    container_name: dds_mailcatcher
     image: sj26/mailcatcher:latest
     profiles:
       - dev
       - mail
       - full-dev
+      - cli
     ports:
       - 127.0.0.1:1080:1080    
 
@@ -108,3 +112,20 @@ services:
     image: redis:latest
     profiles:
       - full-dev
+      - redis
+  
+  cli:
+    container_name: dds_cli
+    build:
+      dockerfile: Dockerfiles/cli.Dockerfile
+      context: ./
+      target: base
+    profiles:
+      - cli
+      - full-dev
+    environment:
+      - DDS_CLI_ENV=docker-dev
+    volumes:
+      - type: bind
+        source: ../dds_cli
+        target: /code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,11 @@ services:
     #     source: ./minio-data
     #     target: /data
 
+#  mailcatcher:
+#    image: sj26/mailcatcher:latest
+#    restart: on-failure
+#    ports:
+#      - 127.0.0.1:1080:1080    
 
 #  redis:
 #    container_name: dds_redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 version: "3.9"
-# for persistent endpoint limiter, uncomment RATELIMIT_STORAGE_URI and the redis entry
+# Use --profile full-dev and uncomment RATELIMIT_STORAGE_URI to use redis
 
 services:
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
   minio:
     image: minio/minio:RELEASE.2022-02-24T22-12-01Z
     profiles:
-      - dev
+      - s3
       - full-dev
     command: server /data --console-address ":9001"
     ports:
@@ -98,6 +98,7 @@ services:
     image: sj26/mailcatcher:latest
     profiles:
       - dev
+      - mail
       - full-dev
     ports:
       - 127.0.0.1:1080:1080    


### PR DESCRIPTION
Should be combined with [#337](https://github.com/ScilifelabDataCentre/dds_cli/pull/337) in dds_cli

Add `Mailcatcher` and `Minio` to the development environment. This should enable a full zero-conf dev environment.

* Mailcatcher catches emails and will make them available at `localhost:1080`
* Minio is used as a local S3 storage, meaning that Safespring won't be needed
* `config.py` has been updated with new defaults, matching the needs of the above services
* Profiles have been added in `docker-compose.yml`
* Readme is updated with a note about the new setup


- `docker-compose up` will start `database` and `backend`
- `docker-compose --profile dev up` will start `database`, `backend`, and `mailcatcher`
- `docker-compose --profile cli up` will start `database`, `backend`, `cli`, `minio`, and `mailcatcher`
- `docker-compose --profile full-dev up` will start `database`, `backend`, `minio`, `mailcatcher`, `cli`, and `redis`

`docker-compose --profile cli up` can be used to have a full local environment for development of both web and cli by starting a shell in `dds_cli`.

Running the "run tests" command
```
docker-compose -f docker-compose.yml -f tests/docker-compose-test.yml up --build --exit-code-from backend
```
will only start the testing `backend` and `database`.

- [X] Tests passing
- [-] Black formatting
- [-] Migrations for any changes to the database schema
- [X] Rebase/merge the `dev` branch
- [X] Note in the CHANGELOG

