### PR TITLE
Run pip install before injecting into the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ Requires that dds_cli is checked out in `../dds_cli` (otherwise adapt the volume
 docker exec -it dds_cli /bin/bash
 ```
 
-3. pip install -e .
-
 Then you can freely use the dds cli component against the local development setup in the active CLI.
 
 ### Python debugger inside docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,7 @@ services:
   
   cli:
     container_name: dds_cli
+    command: bash -c "pip install --upgrade -e . && tail -f /dev/null"
     build:
       dockerfile: Dockerfiles/cli.Dockerfile
       context: ./


### PR DESCRIPTION
As suggested by @ewels the `pip install` command will be run during container creation instead of having to run it after starting a shell in the container.

- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [x] Rebase/merge the `dev` branch
- [ - ] Note in the CHANGELOG

