### PR TITLE
Fix the dark mode switch behaviour

### DIFF
--- a/dds_web/static/js/dds.js
+++ b/dds_web/static/js/dds.js
@@ -23,22 +23,57 @@
   });
 })();
 
+//
+// Dark mode switch
+//
+
+// OS set to dark mode
+if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+  // Only continue if we have no cookie set
+  if (document.cookie.indexOf("ddstheme") == -1) {
+    // Set the dark mode switch to checked
+    document.getElementById("theme-switcher-check").checked = true;
+    document.getElementById("theme-switcher-sun").classList.add("d-none");
+    document.getElementById("theme-switcher-moon").classList.remove("d-none");
+  }
+}
+// OS theme changes (unlikely, but nice to support!)
+window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+  const newTheme = e.matches ? "dark" : "light";
+  // Only continue if we have no cookie set
+  if (document.cookie.indexOf("ddstheme") == -1) {
+    // Set the dark mode switch
+    if (newTheme == "dark") {
+      document.getElementById("theme-switcher-check").checked = true;
+      document.getElementById("theme-switcher-sun").classList.add("d-none");
+      document.getElementById("theme-switcher-moon").classList.remove("d-none");
+    } else {
+      document.getElementById("theme-switcher-check").checked = false;
+      document.getElementById("theme-switcher-sun").classList.remove("d-none");
+      document.getElementById("theme-switcher-moon").classList.add("d-none");
+    }
+  }
+});
+
+// Manually set dark / light mode
+document.querySelector(".theme-switcher").addEventListener("click", (e) => {
+  const theme = document.getElementById("theme-switcher-check").checked ? "dark" : "light";
+  // Change the CSS for the page
+  var newlink = "/static/css/dds_" + theme + ".css";
+  document.getElementById("dds-stylesheet").setAttribute("href", newlink);
+  // Toggle the button
+  document.getElementById("theme-switcher-check").checked = theme == "dark" ? true : false;
+  document.getElementById("theme-switcher-sun").classList.toggle("d-none");
+  document.getElementById("theme-switcher-moon").classList.toggle("d-none");
+  // Set a cookie
+  document.cookie = "ddstheme=" + theme + "; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/";
+  console.log(document.cookie);
+});
+
+//
+// Legacy jQuery code
+//
 $(function () {
   // Initialise Datatables
   $(".datatable").DataTable();
-
-  // Function to switch CSS theme file
-  $(".theme-switcher").click(function (e) {
-    var theme = $("#theme-switcher-check").prop("checked") ? "dark" : "light";
-
-    // Switch the stylesheet
-    var newlink = "/static/css/dds_" + theme + ".css";
-    $("#dds-stylesheet").attr("href", newlink);
-
-    // Toggle the button
-    $(".theme-switcher label i, .theme-switcher label svg").toggleClass("d-none");
-
-    // Set a cookie to remember
-    document.cookie = "ddstheme=" + theme + "; expires=Thu, 2 Dec 2032 12:00:00 UTC; path=/";
-  });
 });

--- a/dds_web/static/scss/dds_auto.scss
+++ b/dds_web/static/scss/dds_auto.scss
@@ -1,2 +1,2 @@
-@import url("dds_light.css");
+@import url("dds_light.css") screen and (prefers-color-scheme: light);
 @import url("dds_dark.css") screen and (prefers-color-scheme: dark);

--- a/dds_web/static/scss/dds_auto.scss
+++ b/dds_web/static/scss/dds_auto.scss
@@ -1,2 +1,2 @@
-@import url("dds_light.css") screen and (prefers-color-scheme: light);
+@import url("dds_light.css");
 @import url("dds_dark.css") screen and (prefers-color-scheme: dark);

--- a/dds_web/static/scss/dds_dark.scss
+++ b/dds_web/static/scss/dds_dark.scss
@@ -70,3 +70,11 @@
 //
 @import "custom";
 @import "homepage";
+
+// Dark-mode specific overwrites
+
+// Custom opacity, not set in cookies-dark-mode, not sure why
+.bg-light {
+  --bs-bg-opacity: 0.2;
+  background-color: rgba(var(--bs-light-rgb), var(--bs-bg-opacity)) !important;
+}

--- a/dds_web/templates/base.html
+++ b/dds_web/templates/base.html
@@ -47,10 +47,12 @@
                             <input class="form-check-input" type="checkbox" id="theme-switcher-check"
                                 {{ 'checked' if request.cookies.get('ddstheme', 'light') == 'dark' }}>
                             <label class="form-check-label" for="theme-switcher-check">
-                                <i class="{{ 'd-none' if request.cookies.get('ddstheme', 'light') == 'dark' }} fas
-                                    fa-sun fa-fw me-2"></i>
-                                <i class="{{ 'd-none' if request.cookies.get('ddstheme', 'light') == 'light' }} fas
-                                    fa-moon fa-fw me-2"></i>
+                                <span id="theme-switcher-sun" class="{{ 'd-none' if request.cookies.get('ddstheme', 'light') == 'dark' }}">
+                                    <i class="fas fa-sun fa-fw me-2"></i>
+                                </span>
+                                <span id="theme-switcher-moon" class="{{ 'd-none' if request.cookies.get('ddstheme', 'light') == 'light' }} ">
+                                    <i class="fas fa-moon fa-fw me-2"></i>
+                                </span>
                             </label>
                         </div>
                     </div>


### PR DESCRIPTION
Rewrote the Javascript that handles the dark mode switch:

- Use javascript, not jQuery
- If no cookie is set:
    - Set the switch status on page load if OS is dark mode
    - Listen to changes to the OS theme and toggle the switch automatically
- On click, set theme and cookie
- Resolved some styling differences between auto-dark-mode and manual-dark-mode
    - In the `dds-auto.css` file the light CSS is always loaded, then we load dark mode on top if request by the OS.
    - I played with making both conditional, but I'm worried that it could have weird side effects for (a) super old / weird browsers and (b) stuff like printing.
    - Instead I just fixed the inconsistencies I could find, like `.bg-light`
 
Javascript could probably be a bit more efficiently written, but seems to work.

- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [ - ] Rebase/merge the `dev` branch
- [ - ] Note in the CHANGELOG
