### PR TITLE
Correct response when email validation fails during project creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Fix format of self deletion email ([#984](https://github.com/ScilifelabDataCentre/dds_web/pull/984))
 - Add a full zero-conf development environment ([#993](https://github.com/ScilifelabDataCentre/dds_web/pull/993))
 - Include frontend build in the backend production target ([#1011](https://github.com/ScilifelabDataCentre/dds_web/pull/1011))
+- Correct response about project being created when email validation fails for users ([#1014](https://github.com/ScilifelabDataCentre/dds_web/pull/1014))

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -460,7 +460,7 @@ class CreateProject(flask_restful.Resource):
             db.session.rollback()
             raise DatabaseError(message="Server Error: Project was not created") from err
         except (
-            marshmallow.ValidationError,
+            marshmallow.exceptions.ValidationError,
             DDSArgumentError,
             AccessDeniedError,
         ) as err:

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -5,6 +5,7 @@
 ####################################################################################################
 
 # Standard Library
+import http
 
 # Installed
 import flask_restful
@@ -470,6 +471,7 @@ class CreateProject(flask_restful.Resource):
         flask.current_app.logger.debug(
             f"Project {new_project.public_id} created by user {auth.current_user().username}."
         )
+
         user_addition_statuses = []
         if "users_to_add" in p_info:
             for user in p_info["users_to_add"]:
@@ -481,7 +483,7 @@ class CreateProject(flask_restful.Resource):
                         new_user_role=user.get("role"),
                         project=new_project,
                     )
-                    if invite_user_result["status"] == 200:
+                    if invite_user_result["status"] == http.HTTPStatus.OK:
                         invite_msg = (
                             f"Invitation sent to {user['email']}. "
                             "The user should have a valid account to be added to a project"
@@ -505,7 +507,7 @@ class CreateProject(flask_restful.Resource):
                     user_addition_statuses.append(addition_status)
 
         return {
-            "status": 200,
+            "status": http.HTTPStatus.OK,
             "message": f"Added new project '{new_project.title}'",
             "project_id": new_project.public_id,
             "user_addition_statuses": user_addition_statuses,


### PR DESCRIPTION
Catch the `ValidationError` for incorrect emails in project creation so we can get a correct message about the project being created while also getting information about incorrect emails.

Earlier:
```
$ dds project create -t t -d d -pi p --researcher asd@asd --owner asd@adsad
     ︵
 ︵ (  )   ︵
(  ) ) (  (  )   SciLifeLab Data Delivery System
 ︶  (  ) ) (    http://dds_backend:5000/
      ︶ (  )    Version 0.0.10
          ︶
Current user: unituser_1
ERROR    Not a valid email address.
```
Now:
```
$ dds project create -t t -d d -pi p --researcher asd@asd --owner asd@adsad
     ︵
 ︵ (  )   ︵
(  ) ) (  (  )   SciLifeLab Data Delivery System
 ︶  (  ) ) (    http://dds_backend:5000/
      ︶ (  )    Version 0.0.10
          ︶
Current user: unituser_1
Project created with id: someunit00023
Error for asd@adsad: {'email': ['Not a valid email address.']}
Error for asd@asd: {'email': ['Not a valid email address.']}
```

Fixes #977.

- [x] Tests passing
- [x] Black formatting
- [-] Migrations for any changes to the database schema
- [X] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG
