### PR TITLE
Forbid superadmin from creating project

### DIFF
--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -427,7 +427,7 @@ class RemoveContents(flask_restful.Resource):
 
 
 class CreateProject(flask_restful.Resource):
-    @auth.login_required(role=["Super Admin", "Unit Admin", "Unit Personnel"])
+    @auth.login_required(role=["Unit Admin", "Unit Personnel"])
     @logging_bind_request
     @json_required
     @handle_validation_errors


### PR DESCRIPTION
Either we prevent super admins from creating projects, or we need to add a `--unit` option, and also require that an existing user is specified. Since the Super Admins should not have access to the data, we cannot encrypt the project keys with the super admin user keys, so then we need to only encrypt with the added users. 

Have decided with the first one for now: Prevent the super admins from creating projects. 

- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [ - ] Rebase/merge the `dev` branch
- [ - ] Note in the CHANGELOG
