### PR TITLE
change delete_folder regex

### DIFF
--- a/dds_web/api/files.py
+++ b/dds_web/api/files.py
@@ -527,11 +527,12 @@ class RemoveDir(flask_restful.Resource):
                 .filter(
                     sqlalchemy.or_(
                         models.File.subpath == sqlalchemy.func.binary(folder),
-                        models.File.subpath.regexp_match(rf"^{folder}(/[^/]+)*$"),
+                        models.File.subpath.regexp_match(rf"^{folder}(\/[^\/]+)*$"),
                     )
                 )
                 .all()
             )
+
         except sqlalchemy.exc.SQLAlchemyError as err:
             raise DatabaseError(message=str(err))
 


### PR DESCRIPTION
Apparently the `/` need escaping in a raw string regex.

- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [ - ] Rebase/merge the `dev` branch
- [ - ] Note in the CHANGELOG
