### PR TITLE
Fix regex for file rm/ls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Include frontend build in the backend production target ([#1011](https://github.com/ScilifelabDataCentre/dds_web/pull/1011))
 - Correct response about project being created when email validation fails for users ([#1014](https://github.com/ScilifelabDataCentre/dds_web/pull/1014))
 - Introduced an additional validator `dds_web.utils.contains_disallowed_characters` to fix issue [#1007](https://github.com/scilifelabdatacentre/dds_web/issues/1007) ([#1021](https://github.com/ScilifelabDataCentre/dds_web/pull/1021)).
+- Fix regex for listing and deleting files [#1029](https://github.com/scilifelabdatacentre/dds_web/issues/1029)

--- a/dds_web/api/files.py
+++ b/dds_web/api/files.py
@@ -6,6 +6,7 @@
 
 # Standard library
 import os
+import re
 
 # Installed
 import flask_restful
@@ -340,8 +341,9 @@ class ListFiles(flask_restful.Resource):
             else:
                 # Get distinct sub folders in specific folder with regex
                 # Match /<something that is not /> x number of times
+                re_folder = re.escape(folder)
                 distinct_folders = (
-                    files.filter(models.File.subpath.regexp_match(rf"^{folder}(/[^/]+)+$"))
+                    files.filter(models.File.subpath.regexp_match(rf"^{re_folder}(/[^/]+)+$"))
                     .with_entities(models.File.subpath)
                     .distinct()
                     .all()
@@ -518,6 +520,7 @@ class RemoveDir(flask_restful.Resource):
         """Delete all items in folder"""
         exists = False
         names_in_bucket = []
+        folder = re.escape(folder)
         try:
             # File names in root
             files = (
@@ -527,7 +530,7 @@ class RemoveDir(flask_restful.Resource):
                 .filter(
                     sqlalchemy.or_(
                         models.File.subpath == sqlalchemy.func.binary(folder),
-                        models.File.subpath.regexp_match(rf"^{folder}(\/[^\/]+)*$"),
+                        models.File.subpath.regexp_match(rf"^{folder}(/[^/]+)*$"),
                     )
                 )
                 .all()

--- a/dds_web/api/files.py
+++ b/dds_web/api/files.py
@@ -520,7 +520,7 @@ class RemoveDir(flask_restful.Resource):
         """Delete all items in folder"""
         exists = False
         names_in_bucket = []
-        folder = re.escape(folder)
+        re_folder = re.escape(folder)
         try:
             # File names in root
             files = (
@@ -530,7 +530,7 @@ class RemoveDir(flask_restful.Resource):
                 .filter(
                     sqlalchemy.or_(
                         models.File.subpath == sqlalchemy.func.binary(folder),
-                        models.File.subpath.regexp_match(rf"^{folder}(/[^/]+)*$"),
+                        models.File.subpath.regexp_match(rf"^{re_folder}(/[^/]+)*$"),
                     )
                 )
                 .all()

--- a/dds_web/api/files.py
+++ b/dds_web/api/files.py
@@ -311,6 +311,8 @@ class ListFiles(flask_restful.Resource):
         # Files have subpath "." and folders do not have child folders
         # Get everything in folder:
         # Files have subpath == folder and folders have child folders (regexp)
+        if folder[-1] == '/':
+            folder = folder[:-1]
         try:
             # All files in project
             files = models.File.query.filter(
@@ -520,6 +522,8 @@ class RemoveDir(flask_restful.Resource):
         """Delete all items in folder"""
         exists = False
         names_in_bucket = []
+        if folder[-1] == '/':
+            folder = folder[:-1]
         re_folder = re.escape(folder)
         try:
             # File names in root

--- a/dds_web/api/files.py
+++ b/dds_web/api/files.py
@@ -311,7 +311,7 @@ class ListFiles(flask_restful.Resource):
         # Files have subpath "." and folders do not have child folders
         # Get everything in folder:
         # Files have subpath == folder and folders have child folders (regexp)
-        if folder[-1] == '/':
+        if folder[-1] == "/":
             folder = folder[:-1]
         try:
             # All files in project
@@ -522,7 +522,7 @@ class RemoveDir(flask_restful.Resource):
         """Delete all items in folder"""
         exists = False
         names_in_bucket = []
-        if folder[-1] == '/':
+        if folder[-1] == "/":
             folder = folder[:-1]
         re_folder = re.escape(folder)
         try:


### PR DESCRIPTION
Escape the folder name before adding using it in a regex. Avoids missinterpretation of e.g. `[]`.

Reverts #1019 since that change did nothing except making the query a bit uglier in the mariadb log.

Closes #1018 

- [X] Tests passing
- [X] Black formatting
- [-] Migrations for any changes to the database schema
- [X] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG
