### PR TITLE
AddUser: Specific error message for unit users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,4 +44,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 
 ## Sprint (2022-03-09 - 2022-03-23)
 
-- Introduce a separate error message if someone tried to add an unit user to projects individually.
+- Introduce a separate error message if someone tried to add an unit user to projects individually. ([#1039](https://github.com/ScilifelabDataCentre/dds_web/pull/1039))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,7 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Introduced an additional validator `dds_web.utils.contains_disallowed_characters` to fix issue [#1007](https://github.com/scilifelabdatacentre/dds_web/issues/1007) ([#1021](https://github.com/ScilifelabDataCentre/dds_web/pull/1021)).
 - Fix regex for listing and deleting files [#1029](https://github.com/scilifelabdatacentre/dds_web/issues/1029)
 - Hides the "Size" and "total_size" variables according to the role and project status ([#1032](https://github.com/ScilifelabDataCentre/dds_web/pull/1032)).
+
+## Sprint (2022-03-09 - 2022-03-23)
+
+- Introduce a separate error message if someone tried to add an unit user to projects individually.

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -267,12 +267,20 @@ class AddUser(flask_restful.Resource):
 
         allowed_roles = ["Project Owner", "Researcher"]
 
-        if role not in allowed_roles or whom.role not in allowed_roles:
+        if role not in allowed_roles:
             return {
                 "status": ddserr.AccessDeniedError.code.value,
                 "message": (
                     "User Role should be either 'Project Owner' or "
                     "'Researcher' to be added to a project"
+                ),
+            }
+
+        if whom.role not in allowed_roles:
+            return {
+                "status": ddserr.AccessDeniedError.code.value,
+                "message": (
+                    "Users affiliated with units can not be added to projects individually."
                 ),
             }
 


### PR DESCRIPTION
Distinct error message if the user to be added to a project is a unit user. 

- [ ] Tests passing
- [x] Black formatting
- [ ] Migrations for any changes to the database schema
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG
