### PR TITLE
make hotp invalid after password reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,4 +48,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Catch KeyNotFoundError when user tries to give access to a project they themselves do not have access to ([#1045](https://github.com/ScilifelabDataCentre/dds_web/pull/1045))
 - Display an error message when the user makes too many authentication requests. ([#1034](https://github.com/ScilifelabDataCentre/dds_web/pull/1034))
 - New endpoint for Unit Personnel and Admins to list the other Unit Personnel / Admins within their project ([#1050](https://github.com/ScilifelabDataCentre/dds_web/pull/1050))
-- Make previous HOTP invalid at password reset ()
+- Make previous HOTP invalid at password reset ([#1054](https://github.com/ScilifelabDataCentre/dds_web/pull/1054))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Catch KeyNotFoundError when user tries to give access to a project they themselves do not have access to ([#1045](https://github.com/ScilifelabDataCentre/dds_web/pull/1045))
 - Display an error message when the user makes too many authentication requests. ([#1034](https://github.com/ScilifelabDataCentre/dds_web/pull/1034))
 - New endpoint for Unit Personnel and Admins to list the other Unit Personnel / Admins within their project ([#1050](https://github.com/ScilifelabDataCentre/dds_web/pull/1050))
+- Make previous HOTP invalid at password reset ()

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -461,6 +461,11 @@ class User(flask_login.UserMixin, db.Model):
         hotp = twofactor_hotp.HOTP(self.hotp_secret, 8, hashes.SHA512())
         return hotp.generate(self.hotp_counter)
 
+    def reset_current_HOTP(self):
+        """Make the previous HOTP as invalid by nulling issue time and increasing counter."""
+        self.hotp_issue_time = None
+        self.hotp_counter += 1
+
     def verify_HOTP(self, token):
         """Verify the HOTP token.
 

--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -372,6 +372,9 @@ def reset_password(token):
 
     # Validate form
     if form.validate_on_submit():
+        # Clear out hotp
+        user.reset_current_HOTP()
+
         # Delete project user keys for user
         for project_user_key in user.project_user_keys:
             db.session.delete(project_user_key)


### PR DESCRIPTION
Tested: 

1. `dds auth login` --> fill in username and password --> get password prompt 
2. Go to web and request password reset
3. Reset password
4. Use the one-time code received in the mail 

This should fail. Before it was ok. 

- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG
