### PR TITLE
Add check to delete user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Return int instead of string from files listing and only return usage info if right role ([#1070](https://github.com/ScilifelabDataCentre/dds_web/pull/1070))
 - Batch deletion of files (breaking atomicity) ([#1067](https://github.com/ScilifelabDataCentre/dds_web/pull/1067))
 - Change token expiration time to 7 days (168 hours) ([#1061](https://github.com/ScilifelabDataCentre/dds_web/pull/1061))
+- Add possibility of deleting invites (temporary fix in delete user endpoint) ([#1075](https://github.com/ScilifelabDataCentre/dds_web/pull/1075))

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -779,10 +779,9 @@ class DeleteUser(flask_restful.Resource):
         try:
             unanswered_invite = user_schemas.UnansweredInvite().load({"email": email})
             if unanswered_invite:
-                if (
-                    current_user_role == "Super Admin"
-                    and unanswered_invite.role not in ["Super Admin", "Unit Admin"]
-                ) or (current_user_role == "Unit Admin" and unanswered_invite.role != "Unit Admin"):
+                if not current_user_role == "Super Admin" or (
+                    current_user_role == "Unit Admin" and unanswered_invite.role == "Super Admin"
+                ):
                     raise ddserr.AccessDeniedError(
                         "You do not have the correct permissions to delete this invite."
                     )

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -700,8 +700,18 @@ class DeleteUser(flask_restful.Resource):
     @logging_bind_request
     @handle_validation_errors
     def delete(self):
+        """Delete user or invite in the DDS."""
+        json_info = flask.request.json
+        if json_info:
+            is_invite = json_info.pop("is_invite", False)
+            if is_invite:
+                unanswered_invite = user_schemas.UnansweredInvite().load(json_info)
+                if unanswered_invite:
+                    db.session.delete(unanswered_invite)
+                    db.session.commit()
+                return {"message": "The invite has been deleted."}
 
-        user = user_schemas.UserSchema().load(flask.request.json)
+        user = user_schemas.UserSchema().load(json_info)
         if not user:
             raise ddserr.UserDeletionError(
                 message=(

--- a/tests/test_user_delete.py
+++ b/tests/test_user_delete.py
@@ -316,6 +316,17 @@ def test_del_invite_no_email(client):
     assert response.json.get("email").get("message") == "The email cannot be null."
 
 
+def test_del_invite_null_email(client):
+    """Super admin deletes invite without specifying email."""
+    response = client.delete(
+        tests.DDSEndpoint.USER_DELETE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(client),
+        json={"email": None, "is_invite": True},
+    )
+    assert response.status_code == http.HTTPStatus.BAD_REQUEST
+    assert response.json.get("email").get("message") == "The email cannot be null."
+
+
 def test_del_invite_superadmin_as_superadmin(client):
     """Super Admin invites super admin and deletes user."""
     invited_user = {"email": "test_user@mailtrap.io", "role": "Super Admin"}

--- a/tests/test_user_delete.py
+++ b/tests/test_user_delete.py
@@ -286,3 +286,124 @@ def test_del_request_others_superaction(client):
     exists = user_from_email(email_to_delete)
     assert exists is None
     assert dds_web.utils.email_in_db(email_to_delete) is False
+
+
+# Test delete invite
+def test_del_invite_non_existent(client):
+    """Super admin deletes non existent invite."""
+    email_to_delete = "incorrect@mailtrap.io"
+    response = client.delete(
+        tests.DDSEndpoint.USER_DELETE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(client),
+        json={"email": email_to_delete, "is_invite": True},
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    assert (
+        f"The invite connected to email '{email_to_delete}' has been deleted."
+        in response.json.get("message")
+    )
+
+
+def test_del_invite_no_email(client):
+    """Super admin deletes invite without specifying email."""
+    response = client.delete(
+        tests.DDSEndpoint.USER_DELETE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(client),
+        json={"is_invite": True},
+    )
+    assert response.status_code == http.HTTPStatus.BAD_REQUEST
+    assert response.json.get("email").get("message") == "The email cannot be null."
+
+
+def test_del_invite_superadmin_as_superadmin(client):
+    """Super Admin invites super admin and deletes user."""
+    invited_user = {"email": "test_user@mailtrap.io", "role": "Super Admin"}
+    response = client.post(
+        tests.DDSEndpoint.USER_ADD,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(client),
+        json=invited_user,
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    invited_user_row = models.Invite.query.filter_by(email=invited_user["email"]).one_or_none()
+    assert invited_user_row and invited_user_row.role == "Super Admin"
+
+    response = client.delete(
+        tests.DDSEndpoint.USER_DELETE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(client),
+        json={"email": invited_user_row.email, "is_invite": True},
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    assert (
+        response.json.get("message")
+        == f"The invite connected to email '{invited_user_row.email}' has been deleted."
+    )
+
+    invited_user_row = models.Invite.query.filter_by(email=invited_user["email"]).one_or_none()
+    assert not invited_user_row
+
+
+def test_del_invite_superadmin_as_unit_admin(client):
+    invited_user = {"email": "test_user@mailtrap.io", "role": "Super Admin"}
+    response = client.post(
+        tests.DDSEndpoint.USER_ADD,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(client),
+        json=invited_user,
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    invited_user_row = models.Invite.query.filter_by(email=invited_user["email"]).one_or_none()
+    assert invited_user_row and invited_user_row.role == "Super Admin"
+
+    response = client.delete(
+        tests.DDSEndpoint.USER_DELETE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
+        json={"email": invited_user_row.email, "is_invite": True},
+    )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN
+    assert (
+        response.json.get("message")
+        == "You do not have the correct permissions to delete this invite."
+    )
+
+    invited_user_row = models.Invite.query.filter_by(email=invited_user["email"]).one_or_none()
+    assert invited_user_row and invited_user_row.role == "Super Admin"
+
+
+def test_del_invite_unit_admin_and_personnel_and_researcher_as_unit_admin(client):
+    unit = models.Unit.query.filter_by(name="Unit 1").one_or_none()
+    invited_users = [
+        {"email": "unitadmin_invite@mailtrap.io", "role": "Unit Admin", "unit": unit.public_id},
+        {
+            "email": "unitpersonnel_invite@mailtrap.io",
+            "role": "Unit Personnel",
+            "unit": unit.public_id,
+        },
+        {"email": "researcher_invite@mailtrap.io", "role": "Researcher"},
+    ]
+    for user in invited_users:
+        print(f"Inviting user: {user}")
+        response = client.post(
+            tests.DDSEndpoint.USER_ADD,
+            headers=tests.UserAuth(tests.USER_CREDENTIALS["superadmin"]).token(client),
+            json=user,
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        invited_user_row = models.Invite.query.filter_by(email=user["email"]).one_or_none()
+        assert invited_user_row and invited_user_row.role == user["role"]
+
+        print(
+            f"Deleting invited user: {invited_user_row.email} ({invited_user_row.role}) as {tests}"
+        )
+        response = client.delete(
+            tests.DDSEndpoint.USER_DELETE,
+            headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
+            json={"email": invited_user_row.email, "is_invite": True},
+        )
+        assert response.status_code == http.HTTPStatus.OK
+        assert (
+            response.json.get("message")
+            == f"The invite connected to email '{invited_user_row.email}' has been deleted."
+        )
+
+        invited_user_row = models.Invite.query.filter_by(email=user["email"]).one_or_none()
+        assert not invited_user_row


### PR DESCRIPTION
Temporary fix until we implement a way to renew the invites. 
This deletes the invite row if you specify is_invite. 

The "The invite has been deleted" independent of whether or not it exists is deliberate.

Signed-off-by: Ina Odén Österbo <inaod568@users.noreply.github.com>

- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG
