### PR TITLE
add validation in schema for description

### DIFF
--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -566,8 +566,12 @@ class CreateProject(flask_restful.Resource):
             return {"warning": warning_message}
 
         # Add a new project to db
+        import pymysql
 
-        new_project = project_schemas.CreateProjectSchema().load(p_info)
+        try:
+            new_project = project_schemas.CreateProjectSchema().load(p_info)
+        except pymysql.err.DataError as err:
+            raise DatabaseError(message="Unexpected database error!")
         db.session.add(new_project)
 
         if not new_project:

--- a/dds_web/api/schemas/project_schemas.py
+++ b/dds_web/api/schemas/project_schemas.py
@@ -6,6 +6,7 @@
 
 # Standard Library
 import os
+import re
 
 # Installed
 import botocore.client
@@ -124,6 +125,15 @@ class CreateProjectSchema(marshmallow.Schema):
             ]
         ):
             raise marshmallow.ValidationError("Missing fields!")
+
+    @marshmallow.validates("description")
+    def validate_description(self, value):
+        """Verify that description only has words, spaces and . / ,."""
+        disallowed = re.findall(r"[^(\w\s.,)]+", value)
+        if disallowed:
+            raise marshmallow.ValidationError(
+                message="The description can only contain letters, spaces, period and commas."
+            )
 
     def generate_bucketname(self, public_id, created_time):
         """Create bucket name for the given project."""

--- a/dds_web/utils.py
+++ b/dds_web/utils.py
@@ -58,7 +58,7 @@ def contains_digit_or_specialchar(indata):
 
 def contains_disallowed_characters(indata):
     """Indatas like <f0><9f><98><80> cause issues in Project names etc."""
-    disallowed = re.findall(r"[^\w\s]+", indata)
+    disallowed = re.findall(r"[^(\w\s)]+", indata)
     if disallowed:
         disallowed = set(disallowed)  # unique values
         chars = "characters"


### PR DESCRIPTION
Description now allows . and , as well as letters and spaces.

- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG
