### PR TITLE
Remove banner on the homepage about testing

### DIFF
--- a/dds_web/templates/home.html
+++ b/dds_web/templates/home.html
@@ -1,16 +1,6 @@
 {% extends 'base.html' %}
 {% block body %}
 
-{#
-    #########################################################
-    ##### TODO: REMOVE THIS ONCE TESTING PERIOD IS OVER #####
-    #########################################################
-#}
-<div class="alert alert-info h4 text-center">
-    For information on how to use the Data Delivery System, as well as to see a testing protocol, see
-    <a href="https://github.com/ScilifelabDataCentre/dds_cli/blob/master/docs/_build/latex/datadeliverysystem.pdf">here</a>.
-</div>
-
 <div class="row mb-5 pb-3">
     <div class="col-lg-6">
         <h1 class="display-4">Welcome to the SciLifeLab Data Delivery System</h1>


### PR DESCRIPTION
Removing this thing:

<img width="1368" alt="image" src="https://user-images.githubusercontent.com/465550/159945011-ca8df07b-218a-4d04-b621-01c6a4700940.png">


- [ ] Tests passing
- [ ] Black formatting
- [ ] Migrations for any changes to the database schema
- [ ] Rebase/merge the `dev` branch
- [ ] Note in the CHANGELOG
