### PR TITLE
Add docs link to top navbar

### DIFF
--- a/dds_web/templates/navbar.html
+++ b/dds_web/templates/navbar.html
@@ -14,9 +14,9 @@
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="#">
+                    <a class="nav-link" href="https://scilifelabdatacentre.github.io/dds_cli/" target="_blank">
                         <i class="far fa-info-circle d-block mx-auto"></i>
-                        About
+                        Documentation
                     </a>
                 </li>
                 {% if g.current_user %}


### PR DESCRIPTION

<img width="366" alt="image" src="https://user-images.githubusercontent.com/465550/160115608-3b393217-ffd2-48cc-932d-5bd076fb7723.png">

Links to the docs in a new tab.

- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [x] Rebase/merge the `dev` branch
- [ - ] Note in the CHANGELOG
