### PR TITLE
Better front-end styling for 2fa confirm page

### DIFF
--- a/dds_web/forms.py
+++ b/dds_web/forms.py
@@ -84,7 +84,7 @@ class LogoutForm(flask_wtf.FlaskForm):
 
 class Confirm2FACodeForm(flask_wtf.FlaskForm):
     hotp = wtforms.StringField(
-        "hotp",
+        "Multi-factor authentication code",
         validators=[wtforms.validators.InputRequired(), wtforms.validators.Length(min=8, max=8)],
     )
     submit = wtforms.SubmitField("Authenticate")

--- a/dds_web/templates/user/confirm2fa.html
+++ b/dds_web/templates/user/confirm2fa.html
@@ -6,32 +6,42 @@ DDS Multi-Factor Authentication
 
 {% block body %}
 
-    <p class="lead">Please enter your one-time authentication code.</p>
-    <p>Please complete the login by entering the one-time authentication code that was sent to you.
-        The one-time codes are valid for a short time (15 minutes) after they have been issued.
-    </p>
-    <form method="POST" action="{{ url_for('auth_blueprint.confirm_2fa', next=next) }}">
-        {{ form.csrf_token }}
+<p class="lead">Please enter your one-time authentication code.</p>
+<p>Please complete the login by entering the one-time authentication code that was sent to you.
+    The one-time codes are valid for a short time (15 minutes) after they have been issued.
+</p>
+<form method="POST" action="{{ url_for('auth_blueprint.confirm_2fa', next=next) }}">
+    {{ form.csrf_token }}
+
+    <div class="row mb-3">
 
         <!-- Token -->
-        {{ form.hotp.label }}
-        {{ form.hotp }}
-        <ul>
-            {% for error in form.hotp.errors %}
-            <li style="color:red;">
-                {{ error }}
-            </li>
-            {% endfor %}
-        </ul>
+        {{ form.hotp.label(class="col-md-auto mb-2 col-form-label") }}
+        <div class="col-md-3">
+            {{ form.hotp(class="form-control mb-2") }}
+        </div>
 
         <!-- Submit button -->
-        {{ form.submit }}
+        <div class="col">
+            <button type="submit" class="btn btn-success mb-2">
+                <i class="fas fa-key me-2"></i>
+                Authenticate
+            </button>
+        </div>
 
-    </form>
+        {% if form.hotp.errors %}
+            {% for error in form.hotp.errors %}
+                <div class="invalid-feedback">{{ error }}</div>
+            {% endfor %}
+        {% endif %}
 
-    <form method="POST" action="{{ url_for('auth_blueprint.cancel_2fa') }}">
-        {{ cancel_form.csrf_token }}
-        {{ cancel_form.cancel }}
-    </form>
+    </div>
+
+</form>
+
+<form method="POST" action="{{ url_for('auth_blueprint.cancel_2fa') }}">
+    {{ cancel_form.csrf_token }}
+    {{ cancel_form.cancel(class="btn btn-link ps-0") }}
+</form>
 
 {% endblock %}

--- a/dds_web/templates/user/confirm2fa.html
+++ b/dds_web/templates/user/confirm2fa.html
@@ -16,7 +16,7 @@ DDS Multi-Factor Authentication
     <div class="row mb-3">
 
         <!-- Token -->
-        {{ form.hotp.label(class="col-md-auto mb-2 col-form-label") }}
+        {{ form.hotp.label(class="col-md-auto col-form-label") }}
         <div class="col-md-3">
             {{ form.hotp(class="form-control mb-2") }}
         </div>


### PR DESCRIPTION
Original:

<img width="1178" alt="image" src="https://user-images.githubusercontent.com/465550/160193445-e1e6a5d4-cfbb-421f-8749-559703ca2fac.png">

New:

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/465550/160193405-6f3130e6-73cf-4e5d-9d86-ed7563cd5dd9.png">


- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [ ] Rebase/merge the `dev` branch
- [ - ] Note in the CHANGELOG
