### PR TITLE
Minor style improvements to 2fa email

### DIFF
--- a/dds_web/templates/mail/authenticate.html
+++ b/dds_web/templates/mail/authenticate.html
@@ -1,25 +1,24 @@
 {% extends 'mail/mail_base.html' %}
 {% block body %}
-<table role="presentation" border="0" cellpadding="0" cellspacing="0"
-    style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
     <tr>
         <td>
-            <img src="cid:Logo" alt="Logo" border="0"
-                style="border:0; outline:none; text-decoration:none; display:block; Margin-bottom: 15px; max-width: 400px; max-height: 87px;">
+            <p style="text-align: center;">
+                <img src="cid:Logo" alt="Logo" border="0" style="border:0; outline:none; text-decoration:none; margin-bottom: 15px; max-width: 400px; max-height: 87px;">
+            </p>
         </td>
     </tr>
     <tr>
         <td style=" font-family: arial, sans-serif; font-size: 14px; vertical-align: top;">
-            <p
-                style="font-family: arial, sans-serif; font-size: 14px; font-weight: bold; margin: 0; Margin-bottom: 5px;">
-                Here is the issued authentication code for SciLifeLab Data Delivery System (DDS)
+            <p style="font-family: arial, sans-serif; font-size: 14px; font-weight: bold; margin: 0; margin-bottom: 5px;">
+                Here is your two-factor authentication code for the SciLifeLab Data Delivery System.
             </p>
-            <p
-                style="font-family: arial, sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-top: 0px;">
-                Please, copy and paste the code below where you attempt to authenticate: </p>
-            <p
-                style="font-family: arial, sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-top: 0px; word-break: break-all">
-                {{one_time_value}}</p>
+            <p style="font-family: arial, sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-top: 0px;">
+                Please, copy and paste the code below in order to log in:
+            </p>
+            <p style="font-family: arial, sans-serif; font-size: 60px; letter-spacing: 5px; text-align: center; background-color: #ededed; margin: 0; margin-top: 15px; word-break: break-all">
+                {{one_time_value}}
+            </p>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
Some CSS tweaks just to make the 2fa code stand out a bit more:

<img width="718" alt="image" src="https://user-images.githubusercontent.com/465550/160420356-9b517304-096b-466e-8573-4a7e4dffd157.png">


- [ ] Tests passing
- [ ] Black formatting
- [ ] Migrations for any changes to the database schema
- [ ] Rebase/merge the `dev` branch
- [ ] Note in the CHANGELOG


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1102"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

