### PR TITLE
Project Access Reset and Send Email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,7 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Let project description include . and , ([#1080](https://github.com/ScilifelabDataCentre/dds_web/pull/1080))
 - Catch OperationalError if there is a database malfunction in `files.py` ([#1089](https://github.com/ScilifelabDataCentre/dds_web/pull/1089))
 - Switched the validation for the principal investigator from string to email ([#1084](https://github.com/ScilifelabDataCentre/dds_web/pull/1084)).
+
+## Sprint (2022-03-23 - 2022-04-06)
+
+- Send an email to all Unit Admins when a Unit Admin has reset their password ([#1110](https://github.com/ScilifelabDataCentre/dds_web/pull/1110)).

--- a/dds_web/templates/mail/project_access_reset.html
+++ b/dds_web/templates/mail/project_access_reset.html
@@ -1,0 +1,23 @@
+{% extends 'mail/mail_base.html' %}
+{% block body %}
+<table role="presentation" border="0" cellpadding="0" cellspacing="0"
+    style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+    <tr>
+        <td>
+            <img src="cid:Logo" alt="Logo" border="0"
+                style="border:0; outline:none; text-decoration:none; display:block; margin-bottom: 15px; max-width: 400px; max-height: 87px;">
+        </td>
+    </tr>
+    <tr>
+        <td style="font-family: arial, sans-serif; font-size: 14px; vertical-align: top;">
+            <p style="font-family: arial, sans-serif; font-size: 14px; font-weight: bold; margin: 0; margin-bottom: 5px;">
+                Important! The Unit Admin, {{email}}, has recently reset their password and therefore lost access to all projects within your
+                unit. To reduce the risk of future data loss, please grant them access again with the following command:
+            </p>
+            <p style="text-align: center">
+                <code>dds project access fix {{email}}</code>
+            </p>
+        </td>
+    </tr>
+</table>
+{% endblock %}

--- a/dds_web/templates/mail/project_access_reset.txt
+++ b/dds_web/templates/mail/project_access_reset.txt
@@ -1,0 +1,5 @@
+Important! The Unit Admin, {{email}}, has recently reset their password and therefore
+lost access to all projects within your unit. To reduce the risk of future data loss,
+please grant them access again with the following command:
+
+    dds project access fix {{email}}

--- a/dds_web/utils.py
+++ b/dds_web/utils.py
@@ -277,6 +277,30 @@ def send_reset_email(email_row, token):
     mail.send(msg)
 
 
+def send_project_access_reset_email(email_row, email, token):
+    """Generate password reset email."""
+    msg = flask_mail.Message(
+        "WARNING! A Unit Admin has lost access",
+        recipients=[email_row.email],
+    )
+
+    # Need to attach the image to be able to use it
+    msg.attach(
+        "scilifelab_logo.png",
+        "image/png",
+        open(os.path.join(flask.current_app.static_folder, "img/scilifelab_logo.png"), "rb").read(),
+        "inline",
+        headers=[
+            ["Content-ID", "<Logo>"],
+        ],
+    )
+
+    msg.body = flask.render_template("mail/project_access_reset.txt", email=email)
+    msg.html = flask.render_template("mail/project_access_reset.html", email=email)
+
+    mail.send(msg)
+
+
 def is_safe_url(target):
     """Check if the url is safe for redirects."""
     ref_url = urllib.parse.urlparse(flask.request.host_url)

--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -448,17 +448,48 @@ def password_reset_completed():
         return flask.redirect(flask.url_for("auth_blueprint.index"))
 
     units_to_contact = {}
+    unit_admins_to_contact = {}
+
     if user.role != "Super Admin":
         for project in user.projects:
-            if project.responsible_unit.external_display_name not in units_to_contact:
-                units_to_contact[
-                    project.responsible_unit.external_display_name
-                ] = project.responsible_unit.contact_email
-        return flask.render_template(
-            "user/password_reset_completed.html", units_to_contact=units_to_contact
-        )
+            if user.role == "Unit Admin":
+                users = (
+                    db.session.query(models.User)
+                    .join(models.UnitUser)
+                    .join(models.Email)
+                    .with_entities(
+                        models.User.username,
+                        models.User.name,
+                        models.UnitUser.unit_id,
+                        models.UnitUser.is_admin,
+                        models.Email.email,
+                    )
+                    .filter(models.UnitUser.unit_id == user.unit_id)
+                    .filter(models.UnitUser.is_admin == True)
+                    .filter(models.User.username != user.username)
+                    .all()
+                )
+                email = (
+                    db.session.query(models.Email)
+                    .with_entities(models.Email.email)
+                    .filter(models.Email.user_id == user.username)
+                    .first()
+                )
 
-    return flask.render_template("user/password_reset_completed.html")
+                unit_admins_to_contact = users
+            else:
+                if project.responsible_unit.external_display_name not in units_to_contact:
+                    units_to_contact[
+                        project.responsible_unit.external_display_name
+                    ] = project.responsible_unit.contact_email
+
+        if len(unit_admins_to_contact) > 0:
+            for unit_admin in unit_admins_to_contact:
+                dds_web.utils.send_project_access_reset_email(unit_admin, email[0], token)
+
+    return flask.render_template(
+        "user/password_reset_completed.html", units_to_contact=units_to_contact
+    )
 
 
 @auth_blueprint.route("/change_password", methods=["GET", "POST"])


### PR DESCRIPTION
This patch sends an email to all Unit Admins when a Unit Admin has reset their password.

Fixes https://github.com/ScilifelabDataCentre/dds_cli/issues/431.

- [X] Tests passing
- [X] Black formatting
- [ - ] Migrations for any changes to the database schema
- [X] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG

<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1110"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

