### PR TITLE
Remove the Gitlens extension from gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -43,7 +43,6 @@ vscode:
     - ms-azuretools.vscode-docker
     - ms-python.python
     - esbenp.prettier-vscode # Linting and style checking
-    - eamodio.gitlens # Quickly glimpse into whom, why, and when a line or code block was changed
     - Gruntfuggly.todo-tree # Display TODO and FIXME in a tree view in the activity bar
 
 github:


### PR DESCRIPTION
It's really spammy on load in the web editor and not really needed.

- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [x] Rebase/merge the `dev` branch
- [ - ] Note in the CHANGELOG


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1111"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

