### PR TITLE
Clarify error messages when incorrect field input e.g. email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,3 +76,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 ## Sprint (2022-04-06 - 2022-04-20)
 
 - New endpoint for adding a message of the day to the database ([#1136](https://github.com/ScilifelabDataCentre/dds_web/pull/1136))
+- Patch: Custom error for PI email validation ([]())

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,4 +76,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 ## Sprint (2022-04-06 - 2022-04-20)
 
 - New endpoint for adding a message of the day to the database ([#1136](https://github.com/ScilifelabDataCentre/dds_web/pull/1136))
-- Patch: Custom error for PI email validation ([]())
+- Patch: Custom error for PI email validation ([#1146](https://github.com/ScilifelabDataCentre/dds_web/pull/1146))

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -608,8 +608,6 @@ class CreateProject(flask_restful.Resource):
             return {"warning": warning_message}
 
         # Add a new project to db
-        import pymysql
-
         try:
             new_project = project_schemas.CreateProjectSchema().load(p_info)
             db.session.add(new_project)
@@ -674,7 +672,7 @@ class CreateProject(flask_restful.Resource):
                         flask.current_app.logger.error(err)
                         addition_status = "Unexpected database error."
                     else:
-                        addition_status = f"Error for {user.get('email')}: {err}"
+                        addition_status = f"Error for '{user.get('email')}': {err}"
                     user_addition_statuses.append(addition_status)
                     continue
 
@@ -704,7 +702,7 @@ class CreateProject(flask_restful.Resource):
                             role=user.get("role"),
                         )
                     except DatabaseError as err:
-                        addition_status = f"Error for {user['email']}: {err.description}"
+                        addition_status = f"Error for '{user['email']}': {err.description}"
                     else:
                         addition_status = add_user_result["message"]
                     user_addition_statuses.append(addition_status)

--- a/dds_web/api/schemas/project_schemas.py
+++ b/dds_web/api/schemas/project_schemas.py
@@ -88,7 +88,7 @@ class CreateProjectSchema(marshmallow.Schema):
     pi = marshmallow.fields.String(
         required=True,
         allow_none=False,
-        validate=marshmallow.validate.Email(),
+        validate=marshmallow.validate.Email(error="The PI email is invalid."),
         error_messages={
             "required": {"message": "A principal investigator is required."},
             "null": {"message": "A principal investigator is required."},


### PR DESCRIPTION
Removed an unused import, added `'` around fields in messages to clarify, and added a custom error message for the PI email.

- [x] Tests passing
- [x] Black formatting
- [ - ] Migrations for any changes to the database schema
- [x] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG
