### PR TITLE
Add unit tests for scheduled_tasks.py functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Cronjob: Scheduled task for deleting unanswered invites after a week ([#1147](https://github.com/ScilifelabDataCentre/dds_web/pull/1147))
 - Checkbox in registration form and policy to agree to ([#1151](https://github.com/ScilifelabDataCentre/dds_web/pull/1151))
 - Patch: Add checks for valid public_id when creating new unit to avoid bucket name errors ([#1154](https://github.com/ScilifelabDataCentre/dds_web/pull/1154))
+- Add unit tests for the "set_available_to_expired" and "set_expired_to_archived" functions ([#1158](https://github.com/ScilifelabDataCentre/dds_web/pull/1158))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,7 +333,11 @@ def add_data_to_db():
     for project in projects:
         project.project_statuses.append(
             ProjectStatuses(
-                **{"status": "In Progress", "date_created": dds_web.utils.current_time()}
+                **{
+                    "status": "In Progress",
+                    "deadline": dds_web.utils.current_time() + datetime.timedelta(weeks=1),
+                    "date_created": dds_web.utils.current_time(),
+                }
             )
         )
     # Create association with files for project 0:

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -16,6 +16,9 @@ from dds_web.scheduled_tasks import set_available_to_expired, set_expired_to_arc
 
 def test_set_available_to_expired(client: flask.testing.FlaskClient) -> None:
     units: List = db.session.query(models.Unit).all()
+    
+    # Set project statuses to Available
+    # and deadline to now to be able to test cronjob functionality
     for unit in units:
         for project in unit.projects:
             for status in project.project_statuses:

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -16,7 +16,6 @@ from dds_web.scheduled_tasks import set_available_to_expired, set_expired_to_arc
 
 def test_set_available_to_expired(client: flask.testing.FlaskClient) -> None:
     units: List = db.session.query(models.Unit).all()
-
     for unit in units:
         for project in unit.projects:
             for status in project.project_statuses:

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -1,11 +1,88 @@
+from datetime import timedelta
+
 import flask
 
-import pytest
+import tests
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
 
 from dds_web import db
 from dds_web.database import models
+from dds_web.utils import current_time
 
-from dds_web.scheduled_tasks import delete_invite
+from dds_web.scheduled_tasks import set_available_to_expired, set_expired_to_archived, delete_invite
+
+
+def test_set_available_to_expired(client: flask.testing.FlaskClient) -> None:
+    units: List = db.session.query(models.Unit).all()
+
+    for unit in units:
+        for project in unit.projects:
+            for status in project.project_statuses:
+                status.deadline = current_time() - timedelta(weeks=1)
+                status.status = "Available"
+
+    i: Int = 0
+    for unit in units:
+        for project in unit.projects:
+            assert len(project.project_statuses) == 1
+            for status in project.project_statuses:
+                if status.status == "Available" and project.current_deadline <= current_time():
+                    i += 1
+                assert (
+                    status.status == "In Progress"
+                    or status.status == "Available"
+                    or status.status == "Expired"
+                )
+    assert i == 5
+
+    set_available_to_expired()
+
+    units: List = db.session.query(models.Unit).all()
+
+    for unit in units:
+        for project in unit.projects:
+            j: Int = 0
+            for status in project.project_statuses:
+                if status.status == "Expired":
+                    j += 1
+            assert j == 1
+
+
+@mock.patch("boto3.session.Session")
+def test_set_expired_to_archived(_: MagicMock, client: flask.testing.FlaskClient) -> None:
+    units: List = db.session.query(models.Unit).all()
+
+    for unit in units:
+        for project in unit.projects:
+            for status in project.project_statuses:
+                status.deadline = current_time() - timedelta(weeks=1)
+                status.status = "Expired"
+
+    i: Int = 0
+    for unit in units:
+        for project in unit.projects:
+            assert len(project.project_statuses) == 1
+            for status in project.project_statuses:
+                if status.status == "Expired":
+                    i += 1
+                assert status.status == "Expired"
+    assert i == 5
+
+    set_expired_to_archived()
+
+    units: List = db.session.query(models.Unit).all()
+
+    i: Int = 0
+    for unit in units:
+        for project in unit.projects:
+            assert len(project.project_statuses) == 2
+            for status in project.project_statuses:
+                if status.status == "Archived":
+                    i += 1
+                assert status.status == "Archived" or status.status == "Expired"
+    assert i == 5
 
 
 def test_delete_invite(client: flask.testing.FlaskClient) -> None:

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -16,7 +16,6 @@ from dds_web.scheduled_tasks import set_available_to_expired, set_expired_to_arc
 
 def test_set_available_to_expired(client: flask.testing.FlaskClient) -> None:
     units: List = db.session.query(models.Unit).all()
-    
     # Set project statuses to Available
     # and deadline to now to be able to test cronjob functionality
     for unit in units:


### PR DESCRIPTION
This patch adds unit tests for the "set_available_to_expired" and "set_expired_to_archived" functions.

Fixes DDS-1156.

- [X] Tests passing
- [X] Black formatting
- [ - ] Migrations for any changes to the database schema
- [X] Rebase/merge the `dev` branch
- [x] Note in the CHANGELOG


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1158"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

