### PR TITLE
Fix for showing the 90 second TOTP warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,3 +95,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Bug: Check for timestamp `0000-00-00 00:00:00` added and invite deleted ([#1163](https://github.com/ScilifelabDataCentre/dds_web/pull/1163))
 - Add documentation of status codes in `api/project.py` ([#1164](https://github.com/ScilifelabDataCentre/dds_web/pull/1164))
 - Add ability to switch to using TOTP and back to HOTP for MFA ([#936](https://github.com/scilifelabdatacentre/dds_web/issues/936))
+- Patch: Fix the warning in web for too soon TOTP login (within 90 seconds) ([#1173](https://github.com/ScilifelabDataCentre/dds_web/pull/1173))

--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -320,8 +320,10 @@ def confirm_2fa():
         # Raises authenticationerror if invalid
         try:
             twofactor_verify(twofactor_value.encode())
-        except ddserr.AuthenticationError:
-            flask.flash("Invalid one-time code.", "warning")
+        except ddserr.AuthenticationError as err:
+            message = str(err)
+            message = message.removeprefix("401 Unauthorized: ")
+            flask.flash(message, "warning")
             return flask.redirect(
                 flask.url_for(
                     "auth_blueprint.confirm_2fa",


### PR DESCRIPTION
When an attempt for login with TOTP is made sooner than 90 seconds before the previous one, the web interface is showing the warning “Invalid one-time code.”. This patch fixes it so that the warning is 
"Authentications with time-based token need to be at least 90 seconds apart."  (cli is showing the this one already)

Please include the following in this section

- [x] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [ ] Any dependencies that are required for this change

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to
- [ ] Changes to the database schema: A new migration is included in the PR

## Formatting and documentation

- [x] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1173"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

