### PR TITLE
Changed bucket check to correct logic and and fixed printout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,3 +98,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Patch: Fix the warning in web for too soon TOTP login (within 90 seconds) ([#1173](https://github.com/ScilifelabDataCentre/dds_web/pull/1173))
 - Bug: Do not remove the bucket when emptying the project ([#1172](https://github.com/ScilifelabDataCentre/dds_web/pull/1172))
 - New `add-missing-buckets` argument option to the `lost-files` flask command ([#1174](https://github.com/ScilifelabDataCentre/dds_web/pull/1174))
+- Bug: Corrected `lost-files` logic and message ([#1176](https://github.com/ScilifelabDataCentre/dds_web/pull/1176))

--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -532,7 +532,7 @@ def lost_files_s3_db(action_type: str):
                         resource.create_bucket(Bucket=project.bucket)
                         flask.current_app.logger.info(f"Bucket '{project.bucket}' created.")
                 continue
-            
+
             # Get objects in project
             try:
                 db_filenames = set(entry.name_in_bucket for entry in project.files)
@@ -542,7 +542,7 @@ def lost_files_s3_db(action_type: str):
             # Differences
             diff_db = db_filenames.difference(s3_filenames)  # In db but not in S3
             diff_s3 = s3_filenames.difference(db_filenames)  # In S3 but not in db
-            
+
             # List all files which are missing in either db of s3
             # or delete the files from the s3 if missing in db, or db if missing in s3
             if action_type == "list":
@@ -589,10 +589,12 @@ def lost_files_s3_db(action_type: str):
             # update the counters at the end of the loop to have accurate numbers for delete
             s3_count += len(diff_s3)
             db_count += len(diff_db)
-    
+
     # Print out information about actions performed in cronjob
     if s3_count or db_count:
-        action_word = "Found" if action_type in ("find", "list", "add-missing-buckets") else "Deleted"
+        action_word = (
+            "Found" if action_type in ("find", "list", "add-missing-buckets") else "Deleted"
+        )
         flask.current_app.logger.info(
             "%s %d entries for lost files (%d in db, %d in s3)",
             action_word,

--- a/dds_web/utils.py
+++ b/dds_web/utils.py
@@ -399,7 +399,7 @@ def bucket_is_valid(bucket_name):
         message = f"The bucket name has the incorrect length {len(bucket_name)}"
     elif re.findall(r"[^a-zA-Z0-9.-]", bucket_name):
         message = "The bucket name contains invalid characters."
-    elif bucket_name[0].isalnum():
+    elif not bucket_name[0].isalnum():
         message = "The bucket name must begin with a letter or number."
     elif bucket_name.count(".") > 2:
         message = "The bucket name cannot contain more than two dots."


### PR DESCRIPTION
# Description

As seen below, the `lost-files` flask command complains that a bucket starting with a letter does not start with a letter. Also, it says that a file has been deleted, but it hasn’t and it shouldn’t. “delete” is apparently the default message.
```
:/code$ flask lost-files add-missing-buckets
/usr/local/lib/python3.10/site-packages/apscheduler/util.py:95: PytzUsageWarning: The zone attribute is specific to pytz's interface; please migrate to a new time zone provider. For more details on how to do so, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
  if obj.zone == 'local':
[2022-05-17 10:32:15,478] __init__ [INFO] Logging initiated.
/usr/local/lib/python3.10/site-packages/apscheduler/triggers/cron/__init__.py:146: PytzUsageWarning: The normalize method is no longer necessary, as this time zone supports the fold attribute (PEP 495). For more details on migrating to a PEP 495-compliant implementation, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
  return self.timezone.normalize(dateval + difference), fieldnum
/usr/local/lib/python3.10/site-packages/apscheduler/triggers/cron/__init__.py:159: PytzUsageWarning: The localize method is no longer necessary, as this time zone supports the fold attribute (PEP 495). For more details on migrating to a PEP 495-compliant implementation, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
  return self.timezone.localize(datetime(**values))
[2022-05-17 10:32:15,880] __init__ [WARNING] Missing bucket snpseq00001-220513122154667651-c911cbcf
[2022-05-17 10:32:15,881] __init__ [WARNING] Could not create bucket 'snpseq00001-220513122154667651-c911cbcf' for project 'snpseq00001': The bucket name must begin with a letter or number.
[2022-05-17 10:32:15,890] __init__ [WARNING] Missing bucket snpseq00002-220516112135701065-ac86de52
[2022-05-17 10:32:15,917] __init__ [WARNING] Could not create bucket 'snpseq00002-220516112135701065-ac86de52' for project 'snpseq00002': The bucket name must begin with a letter or number.
[2022-05-17 10:32:16,014] __init__ [WARNING] Missing bucket ngisthlm00001-220513063100105841-391570c8
[2022-05-17 10:32:16,015] __init__ [WARNING] Could not create bucket 'ngisthlm00001-220513063100105841-391570c8' for project 'ngisthlm00001': The bucket name must begin with a letter or number.
[2022-05-17 10:32:19,239] __init__ [INFO] Deleted 1 entries for lost files (0 in db, 1 in s3)
```

- [x] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [ ] Any dependencies that are required for this change

Fixes DDS-1284

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [x] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to
- [ ] Changes to the database schema: A new migration is included in the PR

## Formatting and documentation

- [x] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1176"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

