### PR TITLE
Allow everything but unicode emojis

### DIFF
--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -611,7 +611,7 @@ class CreateProject(flask_restful.Resource):
         try:
             new_project = project_schemas.CreateProjectSchema().load(p_info)
             db.session.add(new_project)
-        except sqlalchemy.exc.OperationalError as err:
+        except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.SQLAlchemyError) as err:
             raise DatabaseError(message=str(err), alt_message="Unexpected database error.")
 
         if not new_project:

--- a/dds_web/api/schemas/project_schemas.py
+++ b/dds_web/api/schemas/project_schemas.py
@@ -79,7 +79,9 @@ class CreateProjectSchema(marshmallow.Schema):
     description = marshmallow.fields.String(
         required=True,
         allow_none=False,
-        validate=marshmallow.validate.Length(min=1),
+        validate=marshmallow.validate.And(
+            marshmallow.validate.Length(min=1), dds_web.utils.contains_unicode_emojis
+        ),
         error_messages={
             "required": {"message": "A project description is required."},
             "null": {"message": "A project description is required."},
@@ -123,14 +125,6 @@ class CreateProjectSchema(marshmallow.Schema):
         ):
             raise marshmallow.ValidationError("Missing fields!")
 
-    @marshmallow.validates("description")
-    def validate_description(self, value):
-        """Verify that description only has words, spaces and . / ,."""
-        disallowed = re.findall(r"[^(\w\s.,)]+", value)
-        if disallowed:
-            raise marshmallow.ValidationError(
-                message="The description can only contain letters, spaces, period and commas."
-            )
 
     def generate_bucketname(self, public_id, created_time):
         """Create bucket name for the given project."""

--- a/dds_web/api/schemas/project_schemas.py
+++ b/dds_web/api/schemas/project_schemas.py
@@ -125,7 +125,6 @@ class CreateProjectSchema(marshmallow.Schema):
         ):
             raise marshmallow.ValidationError("Missing fields!")
 
-
     def generate_bucketname(self, public_id, created_time):
         """Create bucket name for the given project."""
         return "{pid}-{tstamp}-{rstring}".format(

--- a/dds_web/utils.py
+++ b/dds_web/utils.py
@@ -67,6 +67,30 @@ def contains_disallowed_characters(indata):
         )
 
 
+def contains_unicode_emojis(indata):
+    """Find unicode emojis in string - cause SQLAlchemyErrors."""
+    # Ref: https://gist.github.com/Alex-Just/e86110836f3f93fe7932290526529cd1#gistcomment-3208085
+    # Ref: https://en.wikipedia.org/wiki/Unicode_block
+    EMOJI_PATTERN = re.compile(
+        "(["
+        "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+        "\U0001F300-\U0001F5FF"  # symbols & pictographs
+        "\U0001F600-\U0001F64F"  # emoticons
+        "\U0001F680-\U0001F6FF"  # transport & map symbols
+        "\U0001F700-\U0001F77F"  # alchemical symbols
+        "\U0001F780-\U0001F7FF"  # Geometric Shapes Extended
+        "\U0001F800-\U0001F8FF"  # Supplemental Arrows-C
+        "\U0001F900-\U0001F9FF"  # Supplemental Symbols and Pictographs
+        "\U0001FA00-\U0001FA6F"  # Chess Symbols
+        "\U0001FA70-\U0001FAFF"  # Symbols and Pictographs Extended-A
+        "\U00002702-\U000027B0"  # Dingbats
+        "])"
+    )
+    emojis = re.findall(EMOJI_PATTERN, indata)
+    if emojis:
+        raise marshmallow.ValidationError(f"This input is not allowed: {''.join(emojis)}")
+
+
 def email_not_taken(indata):
     """Validator - verify that email is not taken.
 

--- a/tests/test_project_creation.py
+++ b/tests/test_project_creation.py
@@ -49,7 +49,6 @@ proj_data_with_unsuitable_user_roles = {
 }
 
 
-
 def create_unit_admins(num_admins, unit_id=1):
     new_admins = []
     for i in range(1, num_admins + 1):
@@ -693,6 +692,7 @@ def test_create_project_with_unsuitable_roles(client, boto3_session):
     for x in response.json.get("user_addition_statuses"):
         assert "User Role should be either 'Project Owner' or 'Researcher'" in x
 
+
 def test_create_project_valid_characters(client, boto3_session):
     """Create a project with no unicode."""
     # Project info with valid characters
@@ -705,14 +705,19 @@ def test_create_project_valid_characters(client, boto3_session):
     assert current_unit_admins == 3
 
     response = client.post(
-        tests.DDSEndpoint.PROJECT_CREATE, 
+        tests.DDSEndpoint.PROJECT_CREATE,
         headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
         json=proj_data_val_chars,
     )
     assert response.status_code == http.HTTPStatus.OK
-    
-    new_project = db.session.query(models.Project).filter(models.Project.description == proj_data_val_chars["description"]).first()
+
+    new_project = (
+        db.session.query(models.Project)
+        .filter(models.Project.description == proj_data_val_chars["description"])
+        .first()
+    )
     assert new_project
+
 
 def test_create_project_invalid_characters(client, boto3_session):
     """Create a project with unicode characters."""
@@ -726,13 +731,21 @@ def test_create_project_invalid_characters(client, boto3_session):
     assert current_unit_admins == 3
 
     response = client.post(
-        tests.DDSEndpoint.PROJECT_CREATE, 
+        tests.DDSEndpoint.PROJECT_CREATE,
         headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
         json=proj_data_inval_chars,
     )
     assert response.status_code == http.HTTPStatus.BAD_REQUEST
-    assert response.json and response.json.get("description") and isinstance(response.json.get("description"), list)
+    assert (
+        response.json
+        and response.json.get("description")
+        and isinstance(response.json.get("description"), list)
+    )
     assert response.json["description"][0] == "This input is not allowed: \U0001F300\U0001F601"
 
-    new_project = db.session.query(models.Project).filter(models.Project.description == proj_data_inval_chars["description"]).first()
+    new_project = (
+        db.session.query(models.Project)
+        .filter(models.Project.description == proj_data_inval_chars["description"])
+        .first()
+    )
     assert not new_project


### PR DESCRIPTION
# Description

We previously disallowed a lot of characters from specific fields and decided to go with basically the same thing for the project description. However, the Order Portal allows for all characters, and those using this often collect the order information and use this when creating the data delivery project. This causes the DDS to refuse the project because the description for example contains "invalid characters". 

When looking at this I at first couldn't find what had been producing the errors before, but finally I realised that it's unicode characters and emojis that product SQLAlchemyErrors. In this PR I have changed the description validation to allow all characters except the unicode emojis/signs/characters etc. 

- [x] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [ ] Any dependencies that are required for this change

Fixes DDS-1293

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to
- [ ] Changes to the database schema: A new migration is included in the PR

## Formatting and documentation

- [x] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1178"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

