### PR TITLE
Check for `/api/v1` before validating major cli version

### DIFF
--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -24,7 +24,6 @@ import flask_mail
 import flask_login
 import flask_migrate
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
-from requests import request
 
 # import flask_qrcode
 from werkzeug.middleware.proxy_fix import ProxyFix

--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -24,6 +24,7 @@ import flask_mail
 import flask_login
 import flask_migrate
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+from requests import request
 
 # import flask_qrcode
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -191,8 +192,9 @@ def create_app(testing=False, database_uri=None):
             """Populate flask globals for template rendering"""
             from dds_web.utils import validate_major_cli_version
             from dds_web.errors import VersionMismatchError
-
-            validate_major_cli_version()
+            flask.current_app.logger.debug(flask.request.path)
+            if "/api/v1" in flask.request.path:
+                validate_major_cli_version()
 
             flask.g.current_user = None
             flask.g.current_user_emails = None

--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -192,7 +192,7 @@ def create_app(testing=False, database_uri=None):
             """Populate flask globals for template rendering"""
             from dds_web.utils import validate_major_cli_version
             from dds_web.errors import VersionMismatchError
-            flask.current_app.logger.debug(flask.request.path)
+
             if "/api/v1" in flask.request.path:
                 validate_major_cli_version()
 


### PR DESCRIPTION
# Description

Since the requests to the web endpoints do not have a CLI version in the headers, this adds a quick fix so that the web also works. 

Please include the following in this section

- [x] Summary of the changes and the related issue
- [ ] Relevant motivation and context
- [ ] Any dependencies that are required for this change

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to
- [ ] Changes to the database schema: A new migration is included in the PR

## Formatting and documentation

- [ ] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1195"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

