### PR TITLE
store requests_cache.CachedSession DB in /tmp

### DIFF
--- a/dds_web/utils.py
+++ b/dds_web/utils.py
@@ -456,7 +456,7 @@ def validate_major_cli_version() -> None:
     major_version_request: str = request_version[0]
 
     # Get latest version from PyPi and save to cache
-    session = requests_cache.CachedSession()
+    session = requests_cache.CachedSession('http_cache', backend='sqlite', use_temp=True)
     session.cache_control = True
     session.expire_after = datetime.timedelta(days=0.5)
     try:


### PR DESCRIPTION
For security reasons in our k8s cluster(s) containers are deployed to run as non-root. This means that  requests_cache.CachedSession cannot create its backend sqlite file in the default destination due to lack of permissions. 
Using the parameter use_temp=True solves the issue by setting /tmp as a database directory 

Please include the following in this section

- [ ] Summary of the changes and the related issue
- [ ] Relevant motivation and context
- [ ] Any dependencies that are required for this change

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Rebase/merge the branch which this PR is made to
- [ ] Changes to the database schema: A new migration is included in the PR

## Formatting and documentation

- [ ] I have added a row in the [changelog](../CHANGELOG.md)
- [ ] The code follows the style guidelines of this project: Black / Prettier formatting
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
