### PR TITLE
Parallelism 8 to 4 to be ok with 2 cpu

### DIFF
--- a/dds_web/security/project_user_keys.py
+++ b/dds_web/security/project_user_keys.py
@@ -33,7 +33,7 @@ def __derive_key(user, password):
         salt=user.kd_salt,
         time_cost=2,
         memory_cost=flask.current_app.config["ARGON_KD_MEMORY_COST"],
-        parallelism=8,
+        parallelism=4,
         hash_len=32,
         type=argon2.Type.ID,
     )


### PR DESCRIPTION
# Description

The [key derivation](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/dds_web/security/project_user_keys.py#L31-L37) in dds-dev and dds (prod) uses the settings
- memory cost = 4 GiB
- Parallelism = 8

This means that the function requires
- memory: at least 4 GiB
- cpu: at least 4 (8 / 2)

From what I can tell, the DDS currently has:
- cpu: 2 requested (=> at least), max 4
- memory: 18GiB (=> at least), max 32 GiB

This means that it seems like the memory is enough on the server, but not the CPU. If I've understood it correctly.

As a start of fixing this issue, this PR reduces the parallelism to 4 which according to e.g. [this page](https://www.twelve21.io/how-to-choose-the-right-parameters-for-argon2/) should work with 2 cpu.

- [x] Summary of the changes and the related issue
- [ ] Relevant motivation and context
- [ ] Any dependencies that are required for this change

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to
- [ ] Changes to the database schema: A new migration is included in the PR

## Formatting and documentation

- [ ] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1215"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

