### PR TITLE
Raise accessdenied if user was not found 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,3 +119,7 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - New endpoint for listing all users ([#1204](https://github.com/ScilifelabDataCentre/dds_web/pull/1204))
 - Only print warning about missing bucket if the project is active ([#1203](https://github.com/ScilifelabDataCentre/dds_web/pull/1203))
 - Removed version check ([#1206](https://github.com/ScilifelabDataCentre/dds_web/pull/1206))
+
+## Summer 2022
+
+- Raise AccessDeniedError with message when token specified but user not existent ([#1235](https://github.com/ScilifelabDataCentre/dds_web/pull/1235))

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -231,7 +231,6 @@ def verify_token(token):
     if not user:
         raise AccessDeniedError(message="Invalid token. Try reauthenticating.")
 
-    flask.current_app.logger.debug(type(user.password_reset))
     if user.password_reset:
         token_expired = claims.get("exp")
         token_issued = datetime.datetime.fromtimestamp(token_expired) - MFA_EXPIRES_IN

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -228,7 +228,10 @@ def verify_token(token):
         raise AuthenticationError(message="Invalid token")
 
     user = __user_from_subject(subject=claims.get("sub"))
-
+    if not user:
+        raise AccessDeniedError("Invalid token. Try reauthenticating.")
+        
+    flask.current_app.logger.debug(type(user.password_reset))
     if user.password_reset:
         token_expired = claims.get("exp")
         token_issued = datetime.datetime.fromtimestamp(token_expired) - MFA_EXPIRES_IN

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -229,7 +229,7 @@ def verify_token(token):
 
     user = __user_from_subject(subject=claims.get("sub"))
     if not user:
-        raise AccessDeniedError("Invalid token. Try reauthenticating.")
+        raise AccessDeniedError(message="Invalid token. Try reauthenticating.")
 
     flask.current_app.logger.debug(type(user.password_reset))
     if user.password_reset:

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -230,7 +230,7 @@ def verify_token(token):
     user = __user_from_subject(subject=claims.get("sub"))
     if not user:
         raise AccessDeniedError("Invalid token. Try reauthenticating.")
-        
+
     flask.current_app.logger.debug(type(user.password_reset))
     if user.password_reset:
         token_expired = claims.get("exp")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,37 @@
+import tests
+import http
+from dds_web.database import models
+from dds_web import db
+
+# verify_token
+def test_verify_token_user_not_exists_after_deletion(client):
+    """Log in, delete, log out. Should give exception."""
+    # Check that user exists
+    current_user: models.UnitUser = models.User.query.get("unituser")
+    assert current_user
+
+    # Authenticate
+    token = tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client)
+
+    # Verify that user has access from beginning
+    response = client.get(
+        tests.DDSEndpoint.LIST_FILES, headers=token, query_string={"project": "public_project_id"}
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    # Delete user
+    db.session.delete(current_user)
+    db.session.commit()
+
+    # Check that user dot not exist
+    current_user: models.UnitUser = models.User.query.get("unituser")
+    assert not current_user
+
+    # Attempt run
+    response = client.get(tests.DDSEndpoint.LIST_FILES, headers=token)
+    assert response.status_code == http.HTTPStatus.FORBIDDEN
+
+    # Verify message
+    response_json = response.json
+    message = response_json.get("message")
+    assert message == "Invalid token. Try reauthenticating."


### PR DESCRIPTION
# Description

Logged in to the production instance and then tried to use the dev instance. Then I got this - since it’s not the same user.

```
  File "/code/dds_web/security/auth.py", line 232, in verify_token
    if user.password_reset:
AttributeError: 'NoneType' object has no attribute 'password_reset'
```

Therefore added a line to raise exception if this occurs and ask the user to reauthenticate.

- [x] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [x] Any dependencies that are required for this change

Fixes DDS-1312

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to
- [ ] Changes to the database schema: A new migration is included in the PR

## Formatting and documentation

- [x] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1235"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

