### PR TITLE
add check for hotp activation to not send double mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,3 +119,7 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - New endpoint for listing all users ([#1204](https://github.com/ScilifelabDataCentre/dds_web/pull/1204))
 - Only print warning about missing bucket if the project is active ([#1203](https://github.com/ScilifelabDataCentre/dds_web/pull/1203))
 - Removed version check ([#1206](https://github.com/ScilifelabDataCentre/dds_web/pull/1206))
+
+## Summer 2022
+
+- Do not send one time code to email if the email 2fa is getting activated ([#1236](https://github.com/ScilifelabDataCentre/dds_web/pull/1236))

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -313,9 +313,14 @@ def __handle_multi_factor_authentication(user, mfa_auth_time_string):
 
 def send_hotp_email(user):
     """Send one time code via email."""
-    # Only send if the hotp has not been issued or if it's been more than 15 minutes since
-    # a hotp email was last sent
-    if not user.hotp_issue_time or (
+    # Only send if 
+    # - not trying to activate hotp 
+    # or 
+    # - the hotp has not been issued or if it's been 
+    # more than 15 minutes since a hotp email was last sent
+    if flask.request.path.endswith("/user/hotp/activate"):
+        pass
+    elif not user.hotp_issue_time or (
         user.hotp_issue_time
         and (dds_web.utils.current_time() - user.hotp_issue_time > datetime.timedelta(minutes=15))
     ):

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -313,10 +313,10 @@ def __handle_multi_factor_authentication(user, mfa_auth_time_string):
 
 def send_hotp_email(user):
     """Send one time code via email."""
-    # Only send if 
-    # - not trying to activate hotp 
-    # or 
-    # - the hotp has not been issued or if it's been 
+    # Only send if
+    # - not trying to activate hotp
+    # or
+    # - the hotp has not been issued or if it's been
     # more than 15 minutes since a hotp email was last sent
     if flask.request.path.endswith("/user/hotp/activate"):
         pass


### PR DESCRIPTION
# Description

When HOTP via email is activated for a user and one tries to activate it, it returns a string in the CLI that says that there’s nothing to do because it’s already activated. But there’s still a HOTP email sent out.

Here adding a check for if the endpoint called is the hotp activation. In that case, no email should be sent. 

- [x] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [ ] Any dependencies that are required for this change

Fixes 1281

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to
- [ ] Changes to the database schema: A new migration is included in the PR

## Formatting and documentation

- [x] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1236"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

