### PR TITLE
Unit total stored size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,3 +134,7 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Add Technical Overview page with links to Confluence and to a PDF download ([#1250](https://github.com/ScilifelabDataCentre/dds_web/pull/1250))
 - Technical Overview moved to repository ([#1250](https://github.com/ScilifelabDataCentre/dds_web/pull/1253))
 - Troubleshooting document moved to repository and buttons added to web to link and download ([#1255](https://github.com/ScilifelabDataCentre/dds_web/pull/1255))
+
+## Sprint (2022-09-02 - 2022-09-16)
+
+- Add storage usage information in the Units listing table for Super Admin ([#1264](https://github.com/ScilifelabDataCentre/dds_web/pull/1264))

--- a/dds_web/api/superadmin_only.py
+++ b/dds_web/api/superadmin_only.py
@@ -37,29 +37,19 @@ class AllUnits(flask_restful.Resource):
         """Return info about unit to super admin."""
         all_units = models.Unit.query.all()
 
-        for u in all_units:
-            total_size = 0
-            # 1. get projects
-            projects = models.Project.query.filter_by(unit_id=u.id).all()
-            # 2. for each project
-            #   get size
-            #   accumulate unit size
-            for p in projects:
-                total_size += p.size
-                # 3. add the accumulated size to unit_info
-                unit_info = [
-                    {
-                        "Name": u.name,
-                        "Public ID": u.public_id,
-                        "External Display Name": u.external_display_name,
-                        "Contact Email": u.contact_email,
-                        "Safespring Endpoint": u.safespring_endpoint,
-                        "Days In Available": u.days_in_available,
-                        "Days In Expired": u.days_in_expired,
-                        "Size": total_size,
-                    }
-                ]
-            flask.current_app.logger.debug(f"Tot size stored for unit {u.public_id}: {total_size}")
+        unit_info = [
+            {
+                "Name": u.name,
+                "Public ID": u.public_id,
+                "External Display Name": u.external_display_name,
+                "Contact Email": u.contact_email,
+                "Safespring Endpoint": u.safespring_endpoint,
+                "Days In Available": u.days_in_available,
+                "Days In Expired": u.days_in_expired,
+                "Size": u.size,
+            }
+            for u in all_units
+        ]
 
         return {
             "units": unit_info,

--- a/dds_web/api/superadmin_only.py
+++ b/dds_web/api/superadmin_only.py
@@ -37,18 +37,29 @@ class AllUnits(flask_restful.Resource):
         """Return info about unit to super admin."""
         all_units = models.Unit.query.all()
 
-        unit_info = [
-            {
-                "Name": u.name,
-                "Public ID": u.public_id,
-                "External Display Name": u.external_display_name,
-                "Contact Email": u.contact_email,
-                "Safespring Endpoint": u.safespring_endpoint,
-                "Days In Available": u.days_in_available,
-                "Days In Expired": u.days_in_expired,
-            }
-            for u in all_units
-        ]
+        for u in all_units:
+            total_size = 0
+            # 1. get projects
+            projects = models.Project.query.filter_by(unit_id=u.id).all()
+            # 2. for each project
+            #   get size
+            #   accumulate unit size
+            for p in projects:
+                total_size += p.size
+                # 3. add the accumulated size to unit_info
+                unit_info = [
+                    {
+                        "Name": u.name,
+                        "Public ID": u.public_id,
+                        "External Display Name": u.external_display_name,
+                        "Contact Email": u.contact_email,
+                        "Safespring Endpoint": u.safespring_endpoint,
+                        "Days In Available": u.days_in_available,
+                        "Days In Expired": u.days_in_expired,
+                        "Size": total_size,
+                    }
+                ]
+            flask.current_app.logger.debug(f"Tot size stored for unit {u.public_id}: {total_size}")
 
         return {
             "units": unit_info,
@@ -60,6 +71,7 @@ class AllUnits(flask_restful.Resource):
                 "Days In Expired",
                 "Safespring Endpoint",
                 "Contact Email",
+                "Size",
             ],
         }
 

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -209,6 +209,12 @@ class Unit(db.Model):
         """Called by print, creates representation of object"""
         return f"<Unit {self.public_id}>"
 
+    @property
+    def size(self):
+        """Calculate size of unit - current total storage usage."""
+
+        return sum([p.size for p in self.projects])
+
 
 class Project(db.Model):
     """

--- a/tests/api/test_superadmin_only.py
+++ b/tests/api/test_superadmin_only.py
@@ -86,6 +86,7 @@ def test_list_units_as_super_admin(client: flask.testing.FlaskClient) -> None:
             "Safespring Endpoint": unit.safespring_endpoint,
             "Days In Available": unit.days_in_available,
             "Days In Expired": unit.days_in_expired,
+            "Size": unit.size,
         }
         assert expected in units
 

--- a/tests/api/test_superadmin_only.py
+++ b/tests/api/test_superadmin_only.py
@@ -88,7 +88,7 @@ def test_list_units_as_super_admin(client: flask.testing.FlaskClient) -> None:
             "Days In Expired": unit.days_in_expired,
             "Size": unit.size,
         }
-        
+
         correct_size: int = 0
         for project in unit.projects:
             for file in project.files:

--- a/tests/api/test_superadmin_only.py
+++ b/tests/api/test_superadmin_only.py
@@ -73,6 +73,7 @@ def test_list_units_as_super_admin(client: flask.testing.FlaskClient) -> None:
         "Days In Expired",
         "Safespring Endpoint",
         "Contact Email",
+        "Size",
     ]
     assert len(all_units) == len(units)
 

--- a/tests/api/test_superadmin_only.py
+++ b/tests/api/test_superadmin_only.py
@@ -88,6 +88,12 @@ def test_list_units_as_super_admin(client: flask.testing.FlaskClient) -> None:
             "Days In Expired": unit.days_in_expired,
             "Size": unit.size,
         }
+        
+        correct_size: int = 0
+        for project in unit.projects:
+            for file in project.files:
+                correct_size += file.size_stored
+        assert correct_size == unit.size
         assert expected in units
 
 


### PR DESCRIPTION
# Adds units total stored size to the AllUnits endpoint 

Return the current amount of data stored for a specific unit. 

Should be tested with https://github.com/ScilifelabDataCentre/dds_cli/pull/523

- [ ] Summary of the changes and the related issue
- [x] Relevant motivation and context
- [ ] Any dependencies that are required for this change

Fixes DDS-1324

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [x] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to
- [ ] Changes to the database schema: A new migration is included in the PR
- [ ] Product Owner / Scrum Master: This PR is made to the `master` branch and I have updated the [version](../dds_web/version.py)
- [ ] I am bumping the major version (e.g. 1.x.x to 2.x.x) and I have made the corresponding changes to the CLI version

## Formatting and documentation

- [ ] I have added a row in the [changelog](../CHANGELOG.md)
- [x] The code follows the style guidelines of this project: Black / Prettier formatting
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Tests

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1264"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

