### PR TITLE
Perform a daily trivy scan of latest image

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,7 +3,7 @@ name: trivy
 
 on:
   schedule:
-    - cron: '22 22 * * *'
+    - cron: "22 22 * * *"
 
 jobs:
   scan:
@@ -17,18 +17,18 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Ensure lowercase name
-        run: echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+        run: echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr "[:upper:]" "[:lower:]") >> $GITHUB_ENV
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.7.1
         with:
-          image-ref: 'ghcr.io/${{ env.REPOSITORY_OWNER }}/dds-backend:latest'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          image-ref: "ghcr.io/${{ env.REPOSITORY_OWNER }}/dds-backend:latest"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results.sarif"
           category: trivy

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,8 +1,4 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
+---
 name: trivy
 
 on:
@@ -12,8 +8,8 @@ on:
 jobs:
   scan:
     permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      contents: read
+      security-events: write
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -35,3 +31,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+          category: trivy

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,37 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: trivy
+
+on:
+  schedule:
+    - cron: '22 22 * * *'
+
+jobs:
+  scan:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Ensure lowercase name
+        run: echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.7.1
+        with:
+          image-ref: 'ghcr.io/${{ env.REPOSITORY_OWNER }}/dds-backend:latest'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
# Description

This should add a cronjob that will scan `dds-backend:latest` every night for known CVE and upload any security issues as "Code scanning" issues to the security tab (due to being uploaded by the codeql job).

Please include the following in this section

- [x] Summary of the changes and the related issue
- [x] Relevant motivation and context

## Type of change

- [x] Workflow

# Checklist:

Please delete options that are not relevant.

- [x] Any dependent changes have been merged and published in downstream modules
- [x] Rebase/merge the branch which this PR is made to

## Formatting and documentation

- [x] Prettier / Black

## Tests

-

<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1270"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

