### PR TITLE
Changed cost calc to gbmonth calc

### DIFF
--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -536,13 +536,10 @@ class UserProjects(flask_restful.Resource):
         bhours = 0.0
         cost = 0.0
 
-        flask.current_app.logger.debug(f"Project: {project}")
         for v in project.file_versions:
             # Calculate hours of the current file
             time_deleted = v.time_deleted if v.time_deleted else dds_web.utils.current_time()
             time_uploaded = v.time_uploaded
-            flask.current_app.logger.debug(f"start time: {time_uploaded}")
-            flask.current_app.logger.debug(f"end time: {time_deleted}")
 
             # Calculate BHours
             bhours += dds_web.utils.calculate_bytehours(

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -488,7 +488,7 @@ class UserProjects(flask_restful.Resource):
             project_info["Size"] = proj_size
 
             if usage:
-                proj_bhours, proj_cost = self.project_usage(project=p)
+                proj_bhours, proj_cost = self.project_usage(project=p)                
                 total_bhours_db += proj_bhours
                 total_cost_db += proj_cost
                 # return ByteHours
@@ -536,21 +536,21 @@ class UserProjects(flask_restful.Resource):
         bhours = 0.0
         cost = 0.0
 
+        flask.current_app.logger.debug(f"Project: {project}")
         for v in project.file_versions:
             # Calculate hours of the current file
             time_deleted = v.time_deleted if v.time_deleted else dds_web.utils.current_time()
             time_uploaded = v.time_uploaded
+            flask.current_app.logger.debug(f"start time: {time_uploaded}")
+            flask.current_app.logger.debug(f"end time: {time_deleted}")
 
             # Calculate BHours
             bhours += dds_web.utils.calculate_bytehours(
                 minuend=time_deleted, subtrahend=time_uploaded, size_bytes=v.size_stored
             )
 
-            # Calculate approximate cost per gbhour: kr per gb per month / (days * hours)
-            cost_gbhour = 0.09 / (30 * 24)
-
-            # Save file cost to project info and increase total unit cost
-            cost += bhours / 1e9 * cost_gbhour
+        gbmonths = bhours / (1e9 * 24 * 30) # bhours --> gbhours --> gbdays --> gbmonths
+        cost = gbmonths * 0.09 # cost is in kr per gb per month
 
         return bhours, cost
 

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -488,7 +488,7 @@ class UserProjects(flask_restful.Resource):
             project_info["Size"] = proj_size
 
             if usage:
-                proj_bhours, proj_cost = self.project_usage(project=p)                
+                proj_bhours, proj_cost = self.project_usage(project=p)
                 total_bhours_db += proj_bhours
                 total_cost_db += proj_cost
                 # return ByteHours
@@ -546,8 +546,8 @@ class UserProjects(flask_restful.Resource):
                 minuend=time_deleted, subtrahend=time_uploaded, size_bytes=v.size_stored
             )
 
-        gbmonths = bhours / (1e9 * 24 * 30) # bhours --> gbhours --> gbdays --> gbmonths
-        cost = gbmonths * 0.09 # cost is in kr per gb per month
+        gbmonths = bhours / (1e9 * 24 * 30)  # bhours --> gbhours --> gbdays --> gbmonths
+        cost = gbmonths * 0.09  # cost is in kr per gb per month
 
         return bhours, cost
 


### PR DESCRIPTION
# Description

There seems to be a strange usage / cost bug. While looking at it I realised that the cost per gbhour confused me so I changed to calculate the gbmonth instead so that all we need to do after is multiply with the cost. 

- [x] Relevant motivation and context

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Please delete options that are not relevant.

- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Rebase/merge the branch which this PR is made to
- [ ] Changes to the database schema: A new migration is included in the PR
- [ ] Product Owner / Scrum Master: This PR is made to the `master` branch and I have updated the [version](../dds_web/version.py)
- [ ] I am bumping the major version (e.g. 1.x.x to 2.x.x) and I have made the corresponding changes to the CLI version

## Formatting and documentation

- [ ] I have added a row in the [changelog](../CHANGELOG.md)
- [ ] The code follows the style guidelines of this project: Black / Prettier formatting
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Tests

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1273"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

