### PR TITLE
Dds 1349 new endpoint for sending motd as email

### DIFF
--- a/dds_web/api/__init__.py
+++ b/dds_web/api/__init__.py
@@ -81,6 +81,7 @@ api.add_resource(user.Users, "/users", endpoint="users")
 
 api.add_resource(superadmin_only.AllUnits, "/unit/info/all", endpoint="all_units")
 api.add_resource(superadmin_only.MOTD, "/motd", endpoint="motd")
+api.add_resource(superadmin_only.SendMOTD, "/motd/send", endpoint="send_motd")
 api.add_resource(superadmin_only.FindUser, "/user/find", endpoint="find_user")
 api.add_resource(
     superadmin_only.ResetTwoFactor, "/user/totp/deactivate", endpoint="reset_user_hotp"

--- a/dds_web/api/superadmin_only.py
+++ b/dds_web/api/superadmin_only.py
@@ -158,7 +158,7 @@ class SendMOTD(flask_restful.Resource):
         
         # Get MOTD object
         motd_obj: models.MOTD = models.MOTD.query.get(motd_id)
-        if not motd_obj:
+        if not motd_obj or not motd_obj.active:
             raise ddserr.DDSArgumentError(message=f"There is no active MOTD with ID '{motd_id}'.")
 
         # Create email content
@@ -169,6 +169,7 @@ class SendMOTD(flask_restful.Resource):
 
         # Setup email connection
         with mail.connect() as conn:
+            flask.current_app.logger.info(type(conn))
             # Email users
             for user in utils.page_query(db.session.query(models.User)):
                 primary_email = user.primary_email

--- a/dds_web/api/superadmin_only.py
+++ b/dds_web/api/superadmin_only.py
@@ -135,6 +135,30 @@ class MOTD(flask_restful.Resource):
 
         return {"message": "The MOTD was successfully deactivated in the database."}
 
+class SendMOTD(flask_restful.Resource):
+    """Send a MOTD to all users in database."""
+
+    @auth.login_required(role=["Super Admin"])
+    @logging_bind_request
+    @json_required
+    @handle_db_error
+    def post(self):
+        """Send MOTD as email to users."""
+        # Get MOTD ID
+        motd_id: int = flask.request.json.get("motd_id")
+        if not motd_id or not isinstance(motd_id, int): # The id starts at 1 - ok to not accept 0
+            raise ddserr.DDSArgumentError(
+                message="Please specify the ID of the MOTD you want to send."
+            )
+        
+        # Get MOTD object
+        motd_obj: models.MOTD.query.get(motd_id)
+        if not motd_obj:
+            raise ddserr.DDSArgumentError(message=f"There is no active MOTD with ID '{motd_id}'.")
+            
+
+
+
 
 class FindUser(flask_restful.Resource):
     """Get all users or check if there a specific user in the database."""
@@ -184,3 +208,5 @@ class ResetTwoFactor(flask_restful.Resource):
         return {
             "message": f"TOTP has been deactivated for user: {user.username}. They can now use 2FA via email during authentication."
         }
+
+

--- a/dds_web/api/superadmin_only.py
+++ b/dds_web/api/superadmin_only.py
@@ -7,7 +7,7 @@
 # Standard library
 import os
 import smtplib
-import time 
+import time
 
 # Installed
 import flask_restful
@@ -140,6 +140,7 @@ class MOTD(flask_restful.Resource):
 
         return {"message": "The MOTD was successfully deactivated in the database."}
 
+
 class SendMOTD(flask_restful.Resource):
     """Send a MOTD to all users in database."""
 
@@ -151,11 +152,11 @@ class SendMOTD(flask_restful.Resource):
         """Send MOTD as email to users."""
         # Get MOTD ID
         motd_id: int = flask.request.json.get("motd_id")
-        if not motd_id or not isinstance(motd_id, int): # The id starts at 1 - ok to not accept 0
+        if not motd_id or not isinstance(motd_id, int):  # The id starts at 1 - ok to not accept 0
             raise ddserr.DDSArgumentError(
                 message="Please specify the ID of the MOTD you want to send."
             )
-        
+
         # Get MOTD object
         motd_obj: models.MOTD = models.MOTD.query.get(motd_id)
         if not motd_obj or not motd_obj.active:
@@ -174,14 +175,19 @@ class SendMOTD(flask_restful.Resource):
             for user in utils.page_query(db.session.query(models.User)):
                 primary_email = user.primary_email
                 if not primary_email:
-                    flask.current_app.logger.warning(f"No primary email found for user '{user.username}'.")
+                    flask.current_app.logger.warning(
+                        f"No primary email found for user '{user.username}'."
+                    )
                     pass
-                msg = flask_mail.Message(subject=subject, recipients=[primary_email], body=body, html=html)
+                msg = flask_mail.Message(
+                    subject=subject, recipients=[primary_email], body=body, html=html
+                )
                 msg.attach(
                     "scilifelab_logo.png",
                     "image/png",
                     open(
-                        os.path.join(flask.current_app.static_folder, "img/scilifelab_logo.png"), "rb"
+                        os.path.join(flask.current_app.static_folder, "img/scilifelab_logo.png"),
+                        "rb",
                     ).read(),
                     "inline",
                     headers=[
@@ -242,5 +248,3 @@ class ResetTwoFactor(flask_restful.Resource):
         return {
             "message": f"TOTP has been deactivated for user: {user.username}. They can now use 2FA via email during authentication."
         }
-
-

--- a/dds_web/api/user.py
+++ b/dds_web/api/user.py
@@ -297,18 +297,19 @@ class AddUser(flask_restful.Resource):
         }
 
     @staticmethod
-    def send_email_with_retry(msg, times_retried=0):
+    def send_email_with_retry(msg, times_retried=0, obj=None):
         """Send email with retry on exception"""
-
+        if obj is None:
+            obj = mail
         try:
-            mail.send(msg)
+            obj.send(msg)
         except smtplib.SMTPException as err:
             # Wait a little bit
             time.sleep(10)
             # Retry twice
             if times_retried < 2:
                 retry = times_retried + 1
-                AddUser.send_email_with_retry(msg, retry)
+                AddUser.send_email_with_retry(msg, times_retried=retry, obj=obj)
 
     @staticmethod
     @logging_bind_request

--- a/dds_web/templates/mail/motd.html
+++ b/dds_web/templates/mail/motd.html
@@ -1,0 +1,8 @@
+{% extends 'mail/mail_base.html' %}
+{% block body %}
+Important information to all DDS users:
+
+{{ motd }}
+
+This email cannot be replied to. If you need to get in contact with us regarding the DDS, please send an email to datacentre@scilifelab.se.
+{% endblock %}

--- a/dds_web/templates/mail/motd.html
+++ b/dds_web/templates/mail/motd.html
@@ -1,8 +1,26 @@
 {% extends 'mail/mail_base.html' %}
 {% block body %}
-Important information to all DDS users:
-
-{{ motd }}
-
-This email cannot be replied to. If you need to get in contact with us regarding the DDS, please send an email to datacentre@scilifelab.se.
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+    <tr>
+        <td>
+            <p style="text-align: center;">
+                <img src="cid:Logo" alt="Logo" border="0" style="border:0; outline:none; text-decoration:none; margin-bottom: 15px; max-width: 400px; max-height: 87px;">
+            </p>
+        </td>
+    </tr>
+    <tr>
+        <td style=" font-family: arial, sans-serif; font-size: 14px; vertical-align: top;">
+            <p style="font-family: arial, sans-serif; font-size: 14px; font-weight: bold; margin: 0; margin-bottom: 5px;">
+                Important information to all DDS users:
+            </p>
+            <p style="font-family: arial, sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-top: 0px;">
+                {{ motd }}
+            </p>
+        </td>
+    </tr>
+</table>
+</br></br>
+<p style="font-family: arial, sans-serif; font-size: 12px; font-weight: normal; margin: 0; Margin-top: 0px;">
+    This email cannot be replied to. If you need to get in contact with us regarding the DDS, please send an email to datacentre@scilifelab.se.
+</p>
 {% endblock %}

--- a/dds_web/templates/mail/motd.txt
+++ b/dds_web/templates/mail/motd.txt
@@ -1,0 +1,5 @@
+Important information to all DDS users:
+
+{{ motd }}
+
+This email cannot be replied to. If you need to get in contact with us regarding the DDS, please send an email to datacentre@scilifelab.se.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -221,6 +221,7 @@ class DDSEndpoint:
     # Superadmins only
     LIST_UNITS_ALL = BASE_ENDPOINT + "/unit/info/all"
     MOTD = BASE_ENDPOINT + "/motd"
+    MOTD_SEND = BASE_ENDPOINT + "/motd/send"
     USER_FIND = BASE_ENDPOINT + "/user/find"
     TOTP_DEACTIVATE = BASE_ENDPOINT + "/user/totp/deactivate"
 

--- a/tests/api/test_superadmin_only.py
+++ b/tests/api/test_superadmin_only.py
@@ -6,12 +6,15 @@
 import http
 import time
 import typing
+import unittest
 
 # Installed
 import flask
 import werkzeug
+import flask_mail
 
 # Own
+from dds_web import db
 from dds_web.database import models
 import tests
 
@@ -427,3 +430,116 @@ def test_reset_hotp(client: flask.testing.FlaskClient) -> None:
 
     user_row_again: models.User = models.User.query.filter_by(username=user_row.username).first()
     assert user_row_again and not user_row_again.totp_enabled
+
+
+# SendMOTD #########################################################################################
+
+def test_send_motd_incorrect_method(client: flask.testing.FlaskClient) -> None:
+    """Only post should be accepted."""
+    # Authenticate
+    token: typing.Dict = get_token(username=users["Super Admin"], client=client)
+
+    # Attempt request
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+        for method in [client.get, client, client.head, client.put, client.delete, client.connect, client.options, client.trace, client.patch]:
+            response: werkzeug.test.WrapperTestResponse = method(tests.DDSEndpoint.MOTD_SEND, headers=token, json={"motd_id": "something"})
+            assert response.status_code == http.HTTPStatus.METHOD_NOT_ALLOWED
+        assert mock_mail_send.call_count == 0
+
+def test_send_motd_not_superadmin(client: flask.testing.FlaskClient) -> None:
+    """Only Super Admins should be able to send the motds."""
+    for role in ["Unit Admin", "Unit Personnel", "Researcher"]:
+        # Authenticate
+        token: typing.Dict = get_token(username=users[role], client=client)
+
+        # Attempt request
+        with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+            response: werkzeug.test.WrapperTestResponse = client.post(tests.DDSEndpoint.MOTD_SEND, headers=token, json={"motd_id": "something"})
+            assert response.status_code == http.HTTPStatus.FORBIDDEN
+            assert mock_mail_send.call_count == 0
+
+def test_send_motd_no_json(client: flask.testing.FlaskClient) -> None:
+    """The request needs json in order to send a motd."""
+    # Authenticate
+    token: typing.Dict = get_token(username=users["Super Admin"], client=client)
+
+    # Attempt request
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+        response: werkzeug.test.WrapperTestResponse = client.post(tests.DDSEndpoint.MOTD_SEND, headers=token)
+        assert response.status_code == http.HTTPStatus.BAD_REQUEST
+        assert "Required data missing from request" in response.json.get("message")
+        assert mock_mail_send.call_count == 0
+
+def test_send_motd_no_motdid(client: flask.testing.FlaskClient) -> None:
+    """The json should have motd_id."""
+    # Authenticate
+    token: typing.Dict = get_token(username=users["Super Admin"], client=client)
+
+    # Attempt request
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+        response: werkzeug.test.WrapperTestResponse = client.post(tests.DDSEndpoint.MOTD_SEND, headers=token, json={"test": "something"})
+        assert response.status_code == http.HTTPStatus.BAD_REQUEST
+        assert "Please specify the ID of the MOTD you want to send." in response.json.get("message")
+        assert mock_mail_send.call_count == 0
+
+
+def test_send_motd_nonexistent_motd(client: flask.testing.FlaskClient) -> None:
+    """The motd_id needs to be a valid motd."""
+    # Authenticate
+    token: typing.Dict = get_token(username=users["Super Admin"], client=client)
+
+    # Specify motd to send
+    motd_id: int = 10
+
+    # Attempt request
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+        response: werkzeug.test.WrapperTestResponse = client.post(tests.DDSEndpoint.MOTD_SEND, headers=token, json={"motd_id": motd_id})
+        assert response.status_code == http.HTTPStatus.BAD_REQUEST
+        assert f"There is no active MOTD with ID '{motd_id}'" in response.json.get("message")
+        assert mock_mail_send.call_count == 0
+
+def test_send_motd_ok(client: flask.testing.FlaskClient) -> None:
+    """Send a motd to all users."""
+    # Authenticate
+    token: typing.Dict = get_token(username=users["Super Admin"], client=client)
+
+    # Create a motd
+    message: str = "This is a message that should become a MOTD and then be sent to all the users."
+    new_motd: models.MOTD = models.MOTD(message=message)
+    db.session.add(new_motd)
+    db.session.commit()
+
+    # Make sure the motd is created
+    created_motd: models.MOTD = models.MOTD.query.filter_by(message=message).one_or_none()
+    assert created_motd
+
+    # Get number of users
+    num_users = models.User.query.count()
+
+    # Attempt request
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+        response: werkzeug.test.WrapperTestResponse = client.post(tests.DDSEndpoint.MOTD_SEND, headers=token, json={"motd_id": created_motd.id})
+        assert response.status_code == http.HTTPStatus.OK
+        assert mock_mail_send.call_count == num_users
+
+def test_send_motd_not_active(client: flask.testing.FlaskClient) -> None:
+    """Attempt sending a motd which is not active."""
+    # Authenticate
+    token: typing.Dict = get_token(username=users["Super Admin"], client=client)
+
+    # Create a motd
+    message: str = "This is a message that should become a MOTD and then be sent to all the users."
+    new_motd: models.MOTD = models.MOTD(message=message, active=False)
+    db.session.add(new_motd)
+    db.session.commit()
+
+    # Make sure the motd is created
+    created_motd: models.MOTD = models.MOTD.query.filter_by(message=message).one_or_none()
+    assert created_motd and not created_motd.active
+
+    # Attempt request
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+        response: werkzeug.test.WrapperTestResponse = client.post(tests.DDSEndpoint.MOTD_SEND, headers=token, json={"motd_id": created_motd.id})
+        assert response.status_code == http.HTTPStatus.BAD_REQUEST
+        assert f"There is no active MOTD with ID '{created_motd.id}'" in response.json.get("message")
+        assert mock_mail_send.call_count == 0


### PR DESCRIPTION
> **Before submitting the PR, please go through the sections below and fill in what you can. If there are any items that are irrelevant for the current PR, remove the row. If a relevant option is missing, please add it as an item and add a PR comment informing that the new option should be included into this template.**

> **All _relevant_ items should be ticked before the PR is merged**

# Description

In order to perform maintenance or redeploy the DDS safely and avoid users performing tasks close to it, we need to be a able to inform the users of when the DDS will be down. Sometimes a MOTD unrelated to maintenance may also be very important and sending it as an email will increase the probability of one of the users reading it.

This PR adds a new endpoint which creates a connection to the email server and sends one email to each users primary email. 

- [x] Add a summary of the changes and the related issue
- [x] Add motivation and context regarding why the change is needed
- [x] Fixes DDS-1349 (part of DDS-1326)

## Type of change

- [x] New feature (non-breaking)

# Checklist:

## General

- [ ] [Changelog](../CHANGELOG.md): New row added
- [ ] Database schema has changed
  - [ ] A new migration is included in the PR
  - [ ] The change does not require a migration
- [ ] Code change
  - [ ] Self-review of code done
  - [ ] Comments added, particularly in hard-to-understand areas
  - [ ] Documentation is updated

## Repository / Releases

- [ ] Blocking PRs have been merged
- [ ] Rebase / update of branch done
- [ ] Product Owner / Scrum Master
  - [ ] The [version](../dds_web/version.py) is updated (PR to `master` branch)
  - [ ] I am bumping the major version (e.g. 1.x.x to 2.x.x)
    - [ ] I have made the corresponding changes to the CLI version

## Checks

- [ ] Formatting: Black & Prettier checks pass
- [ ] CodeQL passes
- [ ] Tests
  - [ ] I have added tests for the new code
  - [ ] The tests pass
- [ ] Trivy / Snyk:
  - [ ] There are no new security alerts
  - [ ] This PR fixes new security alerts
  - [ ] Security alerts have been dismissed
  - [ ] PR will be merged with new security alerts; This is why: _Please add a short description here_
