### PR TITLE
Fix the path for dds-reporting.csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,3 +182,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - Dependency: Bump `jwcrypto` due to CVE-2022-3102 ([#1339](https://github.com/ScilifelabDataCentre/dds_web/pull/1339))
 - Cronjob: Get number of units and users for reporting ([#1324](https://github.com/ScilifelabDataCentre/dds_web/pull/1335))
 - Add ability to change project information via ProjectInfo endpoint ([#1331](https://github.com/ScilifelabDataCentre/dds_web/pull/1331))
+- Fix the reporting file path ([1345](https://github.com/ScilifelabDataCentre/dds_web/pull/1345))

--- a/dds_web/scheduled_tasks.py
+++ b/dds_web/scheduled_tasks.py
@@ -322,7 +322,7 @@ def reporting_units_and_users():
     current_date: str = utils.timestamp(ts_format="%Y-%m-%d")
 
     # Location of reporting file
-    reporting_file: pathlib.Path = pathlib.Path("doc/reporting/dds-reporting.csv")
+    reporting_file: pathlib.Path = pathlib.Path("/code/doc/reporting/dds-reporting.csv")
 
     # Error default
     error: str = None

--- a/doc/reporting/dds-reporting.csv
+++ b/doc/reporting/dds-reporting.csv
@@ -1,2 +1,3 @@
 Date,Units using DDS in production,Researchers,Unit users,Total number of users
 2022-11-30,2,108,11,119
+2023-01-02,2,126,11,137

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -124,7 +124,7 @@ def test_quarterly_usage(client: flask.testing.FlaskClient) -> None:
 def test_reporting_units_and_users(client: flask.testing.FlaskClient, fs: FakeFilesystem) -> None:
     """Test that the reporting is giving correct values."""
     # Create reporting file
-    reporting_file: pathlib.Path = pathlib.Path("doc/reporting/dds-reporting.csv")
+    reporting_file: pathlib.Path = pathlib.Path("/code/doc/reporting/dds-reporting.csv")
     assert not fs.exists(reporting_file)
     fs.create_file(reporting_file)
     assert fs.exists(reporting_file)


### PR DESCRIPTION
> **Before submitting the PR, please go through the sections below and fill in what you can. If there are any items that are irrelevant for the current PR, remove the row. If a relevant option is missing, please add it as an item and add a PR comment informing that the new option should be included into this template.**

> **All _relevant_ items should be ticked before the PR is merged**

Since the reporting cron job was failing to find the csv file, see https://scilifelab.zendesk.com/agent/tickets/2645, we change the path 

- [x] Summary of the changes and the related issue:
- [x] Motivation and context regarding why the change is needed:

## Type of change

- [x] Bug fix
  - [x] Non-breaking

_"Breaking": The change will cause existing functionality to not work as expected._

# Checklist:

## General

- [x] [Changelog](../CHANGELOG.md): New row added. Not needed when PR includes _only_ tests.
- [x] Code change
  - [x] Self-review of code done

## Checks

- [x] CodeQL passes
- [x] Formatting: Black & Prettier checks pass
- Tests
  - [x] The tests pass
- Trivy / Snyk:
  - [x] Security alerts have been dismissed: `setuptools` had a vulnerability, but the web does not use the cli in production, and setuptools is not included in the web outside of the cli


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1345"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

