### PR TITLE
Bump CodeQL to v2 since it will be deprecated the 18th

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,7 +56,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
> **Before submitting the PR, please go through the sections below and fill in what you can. If there are any items that are irrelevant for the current PR, remove the row. If a relevant option is missing, please add it as an item and add a PR comment informing that the new option should be included into this template.**

> **All _relevant_ items should be ticked before the PR is merged**

# Description

- [x] Summary of the changes and the related issue: CodeQL v1 will be deprecated on January 18th. Bumping the version to v2. 
- Fixes an issue in GitHub / Jira:
  - [x] No

## Type of change

- [ ] Workflow

# Checklist:

## Repository / Releases

- [ ] Rebase / update of branch done

## Checks

- [ ] CodeQL passes
- [ ] Formatting: Black & Prettier checks pass
- Tests
  - [ ] I have added tests for the new code
  - [ ] The tests pass
- Trivy / Snyk:
  - [ ] There are no new security alerts
  - [ ] This PR fixes new security alerts
  - [ ] Security alerts have been dismissed
  - [ ] PR will be merged with new security alerts; This is why: _Please add a short description here_
