### PR TITLE
Change argon2 password settings

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -226,3 +226,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - PR template restructured ([#1403](https://github.com/ScilifelabDataCentre/dds_web/pull/1403))
 - Only allow latin1-encodable usernames and passwords ([#1402](https://github.com/ScilifelabDataCentre/dds_web/pull/1402))
 - Bug: Corrected calculation of used storage space in `monitor_usage` command ([#1404](https://github.com/ScilifelabDataCentre/dds_web/pull/1404))
+- Config: Define Argon2 settings in `config.py` and use same settings (as default) during password-hashing as in key-derivation for private key access ([#1406](https://github.com/ScilifelabDataCentre/dds_web/pull/1406))

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -36,7 +36,7 @@ class Config(object):
     DDS_SAFESPRING_PROJECT = os.environ.get("DDS_SAFESPRING_PROJECT", "project-name.example.se")
     DDS_SAFESPRING_ACCESS = os.environ.get("DDS_SAFESPRING_ACCESS", "minio")
     DDS_SAFESPRING_SECRET = os.environ.get("DDS_SAFESPRING_SECRET", "minioPassword")
-    
+
     # Use short-lived session cookies:
     PERMANENT_SESSION_LIFETIME = datetime.timedelta(hours=1)
 

--- a/dds_web/config.py
+++ b/dds_web/config.py
@@ -7,6 +7,7 @@
 # Standard library
 import os
 import datetime
+import argon2
 
 ####################################################################################################
 # CLASSES ################################################################################ CLASSES #
@@ -35,7 +36,7 @@ class Config(object):
     DDS_SAFESPRING_PROJECT = os.environ.get("DDS_SAFESPRING_PROJECT", "project-name.example.se")
     DDS_SAFESPRING_ACCESS = os.environ.get("DDS_SAFESPRING_ACCESS", "minio")
     DDS_SAFESPRING_SECRET = os.environ.get("DDS_SAFESPRING_SECRET", "minioPassword")
-
+    
     # Use short-lived session cookies:
     PERMANENT_SESSION_LIFETIME = datetime.timedelta(hours=1)
 
@@ -65,8 +66,20 @@ class Config(object):
 
     INVITATION_EXPIRES_IN_HOURS = 7 * 24
 
+    # Argon2id settings
+    # Key derivation - No config to avoid changing important settings by "accident"
+    ARGON_TIME_COST_KD = 2
     # 512MiB; at least 4GiB (0x400000) recommended in production
-    ARGON_KD_MEMORY_COST = os.environ.get("ARGON_KD_MEMORY_COST", 0x80000)
+    ARGON_MEMORY_COST_KD = os.environ.get("ARGON_MEMORY_COST_KD", 0x80000)
+    ARGON_PARALLELISM_KD = 8
+    ARGON_HASH_LENGTH_KD = 32
+    ARGON_TYPE_KD = argon2.Type.ID
+    # Passwords - Check if specific settings, otherwise set as above
+    ARGON_TIME_COST_PW = os.environ.get("ARGON_TIME_COST_PW", 2)
+    ARGON_MEMORY_COST_PW = os.environ.get("ARGON_MEMORY_COST_PW", ARGON_MEMORY_COST_KD)
+    ARGON_PARALLELISM_PW = os.environ.get("ARGON_PARALLELISM_PW", ARGON_PARALLELISM_KD)
+    ARGON_HASH_LENGTH_PW = os.environ.get("ARGON_HASH_LENGTH_PW", ARGON_HASH_LENGTH_KD)
+    ARGON_TYPE_PW = os.environ.get("ARGON_TYPE_PW", ARGON_TYPE_KD)
 
     SUPERADMIN_USERNAME = os.environ.get("DDS_SUPERADMIN_USERNAME", "superadmin")
     SUPERADMIN_PASSWORD = os.environ.get("DDS_SUPERADMIN_PASSWORD", "password")

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -428,11 +428,11 @@ class User(flask_login.UserMixin, db.Model):
     def password(self, plaintext_password):
         """Generate the password hash and save in db."""
         pw_hasher = argon2.PasswordHasher(
-            time_cost=2,
-            memory_cost=flask.current_app.config["ARGON_KD_MEMORY_COST"],
-            parallelism=8,
-            hash_len=32,
-            type=argon2.Type.ID,
+            time_cost=flask.current_app.config["ARGON_TIME_COST_PW"],
+            memory_cost=flask.current_app.config["ARGON_MEMORY_COST_PW"],
+            parallelism=flask.current_app.config["ARGON_PARALLELISM_PW"],
+            hash_len=flask.current_app.config["ARGON_HASH_LENGTH_PW"],
+            type=flask.current_app.config["ARGON_TYPE_PW"],
         )
         self._password_hash = pw_hasher.hash(plaintext_password)
 
@@ -448,11 +448,11 @@ class User(flask_login.UserMixin, db.Model):
         """Verifies that the specified password matches the encoded password in the database."""
         # Setup Argon2 hasher
         password_hasher = argon2.PasswordHasher(
-            time_cost=2,
-            memory_cost=flask.current_app.config["ARGON_KD_MEMORY_COST"],
-            parallelism=8,
-            hash_len=32,
-            type=argon2.Type.ID,
+            time_cost=flask.current_app.config["ARGON_TIME_COST_PW"],
+            memory_cost=flask.current_app.config["ARGON_MEMORY_COST_PW"],
+            parallelism=flask.current_app.config["ARGON_PARALLELISM_PW"],
+            hash_len=flask.current_app.config["ARGON_HASH_LENGTH_PW"],
+            type=flask.current_app.config["ARGON_TYPE_PW"],
         )
 
         # Verify the input password

--- a/dds_web/database/models.py
+++ b/dds_web/database/models.py
@@ -427,7 +427,13 @@ class User(flask_login.UserMixin, db.Model):
     @password.setter
     def password(self, plaintext_password):
         """Generate the password hash and save in db."""
-        pw_hasher = argon2.PasswordHasher(hash_len=32)
+        pw_hasher = argon2.PasswordHasher(
+            time_cost=2,
+            memory_cost=flask.current_app.config["ARGON_KD_MEMORY_COST"],
+            parallelism=8,
+            hash_len=32,
+            type=argon2.Type.ID,
+        )
         self._password_hash = pw_hasher.hash(plaintext_password)
 
         # User key pair should only be set from here if the password is lost
@@ -441,7 +447,13 @@ class User(flask_login.UserMixin, db.Model):
     def verify_password(self, input_password):
         """Verifies that the specified password matches the encoded password in the database."""
         # Setup Argon2 hasher
-        password_hasher = argon2.PasswordHasher(hash_len=32)
+        password_hasher = argon2.PasswordHasher(
+            time_cost=2,
+            memory_cost=flask.current_app.config["ARGON_KD_MEMORY_COST"],
+            parallelism=8,
+            hash_len=32,
+            type=argon2.Type.ID,
+        )
 
         # Verify the input password
         try:
@@ -456,6 +468,9 @@ class User(flask_login.UserMixin, db.Model):
 
         # Rehash password if needed, e.g. if parameters are not up to date
         if password_hasher.check_needs_rehash(self._password_hash):
+            flask.current_app.logger.info(
+                "The Argon2id settings have changed; The password requires a rehash."
+            )
             try:
                 self.password = input_password
                 db.session.commit()

--- a/dds_web/security/project_user_keys.py
+++ b/dds_web/security/project_user_keys.py
@@ -27,11 +27,11 @@ def __derive_key(user, password):
     derived_key = argon2.low_level.hash_secret_raw(
         secret=password.encode(),
         salt=user.kd_salt,
-        time_cost=2,
-        memory_cost=flask.current_app.config["ARGON_KD_MEMORY_COST"],
-        parallelism=8,
-        hash_len=32,
-        type=argon2.Type.ID,
+        time_cost=flask.current_app.config["ARGON_TIME_COST_KD"],
+        memory_cost=flask.current_app.config["ARGON_MEMORY_COST_KD"],
+        parallelism=flask.current_app.config["ARGON_PARALLELISM_KD"],
+        hash_len=flask.current_app.config["ARGON_HASH_LENGTH_KD"],
+        type=flask.current_app.config["ARGON_TYPE_KD"],
     )
 
     if len(derived_key) != 32:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -294,7 +294,7 @@ def test_verify_password_rehash_needed(client, capfd):
     config = Config()
 
     # ------------------------------------------------------
-    # Change settings -- only hash_len set
+    # Set hash length to previous setting -- as a start point for testing changes
     pw_hasher_0 = argon2.PasswordHasher(
         hash_len=config.ARGON_HASH_LENGTH_PW,
     )

--- a/tests/test_project_user_keys.py
+++ b/tests/test_project_user_keys.py
@@ -2,6 +2,7 @@ import http
 import uuid
 import argon2
 import itertools
+import typing
 
 import pytest
 from cryptography.hazmat.primitives import serialization
@@ -39,7 +40,7 @@ def __padding():
     )
 
 
-def verify_list_items_not_equal(lst):
+def verify_list_items_not_equal(lst: typing.List):
     """Confirm that none of the items matches another."""
     for a, b in itertools.combinations(lst, 2):
         assert a != b

--- a/tests/test_project_user_keys.py
+++ b/tests/test_project_user_keys.py
@@ -164,432 +164,432 @@ def test_derive_key_changed_settings(client):
     )
 
 
-# def test_user_key_setup_error_with_salt(client):
-#     # user is created without a password, so salt will be missing
-#     user = models.User(username="testuser")
-
-#     with pytest.raises(KeySetupError) as error:
-#         generate_user_key_pair(user, "password")
-
-#     assert "User keys are not properly setup!" in str(error.value)
-
-
-# def test_user_key_setup_error_with_private_key(client):
-#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-#     unituser = models.User.query.filter_by(username="unituser").first()
-#     unituser_token = encrypted_jwt_token(
-#         username=unituser.username,
-#         sensitive_content="password",
-#     )
-
-#     # Somehow private key has disappeared
-#     unituser.private_key = None
-
-#     with pytest.raises(KeySetupError) as error:
-#         share_project_private_key(
-#             from_user=unituser,
-#             to_another=invite1,
-#             from_user_token=unituser_token,
-#             project=unituser.unit.projects[0],
-#         )
-
-#     assert "User keys are not properly setup!" in str(error.value)
-
-
-# def test_user_key_setup_error_with_nonce(client):
-#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-#     unituser = models.User.query.filter_by(username="unituser").first()
-#     unituser_token = encrypted_jwt_token(
-#         username=unituser.username,
-#         sensitive_content="password",
-#     )
-
-#     # Somehow nonce has disappeared
-#     unituser.nonce = None
-
-#     with pytest.raises(KeySetupError) as error:
-#         share_project_private_key(
-#             from_user=unituser,
-#             to_another=invite1,
-#             from_user_token=unituser_token,
-#             project=unituser.unit.projects[0],
-#         )
-
-#     assert "User keys are not properly setup!" in str(error.value)
-
-
-# def test_user_key_setup_error_with_public_key(client):
-#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-
-#     # Somehow the key pair for the invite has not taken place or disappeared
-
-#     unituser = models.User.query.filter_by(username="unituser").first()
-#     unituser_token = encrypted_jwt_token(
-#         username=unituser.username,
-#         sensitive_content="password",
-#     )
-#     with pytest.raises(KeySetupError) as error:
-#         share_project_private_key(
-#             from_user=unituser,
-#             to_another=invite1,
-#             from_user_token=unituser_token,
-#             project=unituser.unit.projects[0],
-#         )
-
-#     assert "User keys are not properly setup!" in str(error.value)
-
-
-# def test_user_key_operation_error_with_load_user_public_key(client):
-#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-#     generate_invite_key_pair(invite1)
-#     unituser = models.User.query.filter_by(username="unituser").first()
-#     unituser_token = encrypted_jwt_token(
-#         username=unituser.username,
-#         sensitive_content="password",
-#     )
-
-#     # Somehow the public key of the invite is not the expected public key
-#     invite1.public_key = b"useless_bytes"
-
-#     with pytest.raises(KeyOperationError) as error:
-#         share_project_private_key(
-#             from_user=unituser,
-#             to_another=invite1,
-#             from_user_token=unituser_token,
-#             project=unituser.unit.projects[0],
-#         )
-
-#     assert "User public key could not be loaded!" in str(error.value)
-
-
-# def test_user_key_operation_error_with_decrypt_user_private_key(client):
-#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-#     unituser = models.User.query.filter_by(username="unituser").first()
-
-#     # Somehow a wrong password has ended up in the encrypted token
-#     unituser_token = encrypted_jwt_token(
-#         username=unituser.username,
-#         sensitive_content="passwor",
-#     )
-#     with pytest.raises(KeyOperationError) as error:
-#         share_project_private_key(
-#             from_user=unituser,
-#             to_another=invite1,
-#             from_user_token=unituser_token,
-#             project=unituser.unit.projects[0],
-#         )
-
-#     assert "User private key could not be decrypted!" in str(error.value)
-
-
-# def test_sensitive_content_missing_error(client):
-#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-#     unituser = models.User.query.filter_by(username="unituser").first()
-
-#     # Somehow the password is missing in the encrypted token
-#     unituser_token = encrypted_jwt_token(
-#         username=unituser.username,
-#         sensitive_content=None,
-#     )
-#     with pytest.raises(SensitiveContentMissingError) as error:
-#         share_project_private_key(
-#             from_user=unituser,
-#             to_another=invite1,
-#             from_user_token=unituser_token,
-#             project=unituser.unit.projects[0],
-#         )
-
-#     assert "Sensitive content is missing in the encrypted token!" in str(error.value)
-
-
-# def test_user_key_not_found_error_for_project(client):
-#     project_without_keys = models.Project(
-#         public_id="random_project_id",
-#         title="random project_title",
-#         description="This is a random project. ",
-#         pi="PI",
-#         bucket=f"publicproj-{str(timestamp(ts_format='%Y%m%d%H%M%S'))}-{str(uuid.uuid4())}",
-#     )
-
-#     # Somehow the key pair for the project is not created or persisted to the database
-
-#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-#     unituser = models.User.query.filter_by(username="unituser").first()
-#     unituser.unit.projects.append(project_without_keys)
-#     dds_web.db.session.commit()
-#     unituser_token = encrypted_jwt_token(
-#         username=unituser.username,
-#         sensitive_content="password",
-#     )
-#     with pytest.raises(KeyNotFoundError) as error:
-#         share_project_private_key(
-#             from_user=unituser,
-#             to_another=invite1,
-#             from_user_token=unituser_token,
-#             project=project_without_keys,
-#         )
-
-#     assert "Unrecoverable key error. Aborting." in str(error.value)
-
-
-# def test_user_key_generation(client):
-#     user = models.User(username="testuser", password="password")
-#     assert user.public_key
-#     assert isinstance(serialization.load_der_public_key(user.public_key), RSAPublicKey)
-#     assert user.nonce
-#     assert user.private_key
-
-
-# def test_project_key_generation(client):
-#     # Setup is done in conftest.py
-#     project = models.Project.query.filter_by(public_id="public_project_id").first()
-#     assert project.public_key
-#     assert isinstance(X25519PublicKey.from_public_bytes(project.public_key), X25519PublicKey)
-#     number_of_unitusers_with_project_key = 0
-#     project_user_keys = project.project_user_keys
-#     for project_user_key in project_user_keys:
-#         if (
-#             project_user_key.user_id == "unituser"
-#             or project_user_key.user_id == "unituser2"
-#             or project_user_key.user_id == "unitadmin"
-#         ):
-#             number_of_unitusers_with_project_key += 1
-#     assert number_of_unitusers_with_project_key == 3
-#     user = project_user_keys[0].user
-#     assert user.nonce
-#     assert user.private_key
-
-
-# def test_project_key_sharing(client):
-#     # Setup is done in conftest.py
-#     project = models.Project.query.filter_by(public_id="public_project_id").first()
-#     researchuser = models.User.query.filter_by(username="researchuser").first()
-#     project_researchuser_key = models.ProjectUserKeys.query.filter_by(
-#         project_id=project.id, user_id=researchuser.username
-#     ).first()
-#     assert project_researchuser_key
-#     assert researchuser.nonce
-#     assert researchuser.private_key
-
-#     unituser = models.User.query.filter_by(username="unituser").first()
-#     project_unituser_key = models.ProjectUserKeys.query.filter_by(
-#         project_id=project.id, user_id=unituser.username
-#     ).first()
-#     assert project_unituser_key
-#     assert unituser.nonce
-#     assert unituser.private_key
-
-
-# def test_delete_user_deletes_project_user_keys(client):
-#     """Unit Admin deletes unit user"""
-
-#     email_to_delete = "unituser2@mailtrap.io"
-
-#     project_unituser2_keys_before_delete = models.ProjectUserKeys.query.filter_by(
-#         user_id="unituser2"
-#     ).all()
-#     assert len(project_unituser2_keys_before_delete) == 5
-
-#     response = client.delete(
-#         tests.DDSEndpoint.USER_DELETE,
-#         headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
-#         json={"email": email_to_delete},
-#     )
-#     assert response.status_code == http.HTTPStatus.OK
-
-#     # Make sure that user was deleted
-#     exists = user_from_email(email_to_delete)
-#     assert exists is None
-#     assert dds_web.utils.email_in_db(email_to_delete) is False
-
-#     project_unituser2_keys_after_delete = models.ProjectUserKeys.query.filter_by(
-#         user_id="unituser2"
-#     ).all()
-#     assert len(project_unituser2_keys_after_delete) == 0
-
-
-# def test_remove_user_from_project_deletes_project_user_keys(client):
-#     """Remove an associated user from a project"""
-
-#     username = "researchuser2"
-#     email = "researchuser2@mailtrap.io"
-#     public_id = "second_public_project_id"
-#     user_to_remove = {"email": email}
-#     project = models.Project.query.filter_by(public_id=public_id).first()
-#     assert project
-#     researchuser = models.User.query.filter_by(username=username).first()
-#     assert researchuser
-#     project_user_keys = models.ProjectUserKeys.query.filter_by(
-#         project_id=project.id, user_id=researchuser.username
-#     ).all()
-#     assert len(project_user_keys) == 1
-
-#     response = client.post(
-#         tests.DDSEndpoint.REMOVE_USER_FROM_PROJ,
-#         headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
-#         query_string={"project": project.public_id},
-#         json=user_to_remove,
-#     )
-#     assert response.status_code == http.HTTPStatus.OK
-#     assert (
-#         f"User with email {email} no longer associated with {project.public_id}."
-#         in response.json["message"]
-#     )
-#     project_user_key = models.ProjectUserKeys.query.filter_by(
-#         project_id=project.id, user_id=researchuser.username
-#     ).first()
-#     assert not project_user_key
-
-
-# def test_share_project_keys_via_two_invites(client):
-#     # this test focuses only on the secure parts related to the following scenario
-
-#     # unituser invites a new Unit Personnel
-#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-#     temporary_key = generate_invite_key_pair(invite1)
-#     invite_token1 = encrypted_jwt_token(
-#         username="",
-#         sensitive_content=temporary_key.hex(),
-#         additional_claims={"inv": invite1.email},
-#     )
-#     unituser = models.User.query.filter_by(username="unituser").first()
-#     unituser.unit.invites.append(invite1)
-#     unituser_token = encrypted_jwt_token(
-#         username=unituser.username,
-#         sensitive_content="password",
-#     )
-#     for project in unituser.unit.projects:
-#         share_project_private_key(
-#             from_user=unituser,
-#             to_another=invite1,
-#             from_user_token=unituser_token,
-#             project=project,
-#         )
-#     dds_web.db.session.commit()
-
-#     # ************************************
-
-#     # invited Unit Personnel follows the link and registers itself
-#     common_user_fields = {
-#         "username": "user_not_existing",
-#         "password": "Password123",
-#         "name": "Test User",
-#     }
-#     new_user = models.UnitUser(**common_user_fields)
-#     invite1.unit.users.append(new_user)
-#     new_email = models.Email(email=invite1.email, primary=True)
-#     new_user.emails.append(new_email)
-#     new_user.active = True
-#     dds_web.db.session.add(new_user)
-#     verify_and_transfer_invite_to_user(invite_token1, new_user, common_user_fields["password"])
-#     for project_invite_key in invite1.project_invite_keys:
-#         project_user_key = models.ProjectUserKeys(
-#             project_id=project_invite_key.project_id,
-#             user_id=new_user.username,
-#             key=project_invite_key.key,
-#         )
-#         dds_web.db.session.add(project_user_key)
-#         dds_web.db.session.delete(project_invite_key)
-
-#     assert invite1.nonce != new_user.nonce
-#     assert invite1.public_key == new_user.public_key
-#     assert invite1.private_key != new_user.private_key
-
-#     dds_web.db.session.delete(invite1)
-#     dds_web.db.session.commit()
-
-#     # ************************************
-
-#     # new Unit Personnel invites another new Unit Personnel
-#     invite2 = models.Invite(email="another_unit_user@mailtrap.io", role="Unit Personnel")
-#     invite_token2 = encrypted_jwt_token(
-#         username="",
-#         sensitive_content=generate_invite_key_pair(invite2).hex(),
-#         additional_claims={"inv": invite2.email},
-#     )
-#     unituser = models.User.query.filter_by(username="user_not_existing").first()
-#     unituser.unit.invites.append(invite2)
-#     unituser_token = encrypted_jwt_token(
-#         username=unituser.username,
-#         sensitive_content=common_user_fields["password"],
-#     )
-#     for project in unituser.unit.projects:
-#         share_project_private_key(
-#             from_user=unituser,
-#             to_another=invite2,
-#             from_user_token=unituser_token,
-#             project=project,
-#         )
-#     dds_web.db.session.commit()
-
-#     project_invite_keys = invite2.project_invite_keys
-#     number_of_asserted_projects = 0
-#     for project_invite_key in project_invite_keys:
-#         if (
-#             project_invite_key.project.public_id == "public_project_id"
-#             or project_invite_key.project.public_id == "unused_project_id"
-#             or project_invite_key.project.public_id == "restricted_project_id"
-#             or project_invite_key.project.public_id == "second_public_project_id"
-#             or project_invite_key.project.public_id == "file_testing_project"
-#         ):
-#             number_of_asserted_projects += 1
-#     assert len(project_invite_keys) == number_of_asserted_projects
-#     assert len(project_invite_keys) == 5
-
-
-# def test_update_user_keys_for_password_change(client):
-#     user = models.User(username="randomtestuser", password="password")
-
-#     public_key_initial = user.public_key
-#     nonce_initial = user.nonce
-#     private_key_initial = user.private_key
-#     kd_salt_initial = user.kd_salt
-
-#     assert public_key_initial
-#     assert nonce_initial
-#     assert private_key_initial
-#     assert kd_salt_initial
-
-#     update_user_keys_for_password_change(user, "password", "bogus")
-#     user.password = "bogus"
-
-#     public_key_after_password_change = user.public_key
-#     nonce_after_password_change = user.nonce
-#     private_key_after_password_change = user.private_key
-#     kd_salt_after_password_change = user.kd_salt
-
-#     assert public_key_after_password_change
-#     assert nonce_after_password_change
-#     assert private_key_after_password_change
-#     assert kd_salt_after_password_change
-
-#     assert public_key_after_password_change == public_key_initial
-#     assert nonce_after_password_change != nonce_initial
-#     assert private_key_after_password_change != private_key_initial
-#     assert kd_salt_after_password_change != kd_salt_initial
-
-#     # It shouldn't matter whichever comes first between set password
-#     # and update user keys as the password is not stored in database
-
-#     user.password = "password"
-#     update_user_keys_for_password_change(user, "bogus", "password")
-
-#     public_key_final = user.public_key
-#     nonce_final = user.nonce
-#     private_key_final = user.private_key
-#     kd_salt_final = user.kd_salt
-
-#     assert public_key_final
-#     assert nonce_final
-#     assert private_key_final
-#     assert kd_salt_final
-
-#     assert public_key_final == public_key_initial
-#     assert nonce_final != nonce_initial
-#     assert private_key_final != private_key_initial
-#     assert kd_salt_final != kd_salt_initial
-
-#     assert public_key_after_password_change == public_key_final
-#     assert nonce_after_password_change != nonce_final
-#     assert private_key_after_password_change != private_key_final
-#     assert kd_salt_after_password_change != kd_salt_final
+def test_user_key_setup_error_with_salt(client):
+    # user is created without a password, so salt will be missing
+    user = models.User(username="testuser")
+
+    with pytest.raises(KeySetupError) as error:
+        generate_user_key_pair(user, "password")
+
+    assert "User keys are not properly setup!" in str(error.value)
+
+
+def test_user_key_setup_error_with_private_key(client):
+    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+    unituser = models.User.query.filter_by(username="unituser").first()
+    unituser_token = encrypted_jwt_token(
+        username=unituser.username,
+        sensitive_content="password",
+    )
+
+    # Somehow private key has disappeared
+    unituser.private_key = None
+
+    with pytest.raises(KeySetupError) as error:
+        share_project_private_key(
+            from_user=unituser,
+            to_another=invite1,
+            from_user_token=unituser_token,
+            project=unituser.unit.projects[0],
+        )
+
+    assert "User keys are not properly setup!" in str(error.value)
+
+
+def test_user_key_setup_error_with_nonce(client):
+    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+    unituser = models.User.query.filter_by(username="unituser").first()
+    unituser_token = encrypted_jwt_token(
+        username=unituser.username,
+        sensitive_content="password",
+    )
+
+    # Somehow nonce has disappeared
+    unituser.nonce = None
+
+    with pytest.raises(KeySetupError) as error:
+        share_project_private_key(
+            from_user=unituser,
+            to_another=invite1,
+            from_user_token=unituser_token,
+            project=unituser.unit.projects[0],
+        )
+
+    assert "User keys are not properly setup!" in str(error.value)
+
+
+def test_user_key_setup_error_with_public_key(client):
+    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+
+    # Somehow the key pair for the invite has not taken place or disappeared
+
+    unituser = models.User.query.filter_by(username="unituser").first()
+    unituser_token = encrypted_jwt_token(
+        username=unituser.username,
+        sensitive_content="password",
+    )
+    with pytest.raises(KeySetupError) as error:
+        share_project_private_key(
+            from_user=unituser,
+            to_another=invite1,
+            from_user_token=unituser_token,
+            project=unituser.unit.projects[0],
+        )
+
+    assert "User keys are not properly setup!" in str(error.value)
+
+
+def test_user_key_operation_error_with_load_user_public_key(client):
+    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+    generate_invite_key_pair(invite1)
+    unituser = models.User.query.filter_by(username="unituser").first()
+    unituser_token = encrypted_jwt_token(
+        username=unituser.username,
+        sensitive_content="password",
+    )
+
+    # Somehow the public key of the invite is not the expected public key
+    invite1.public_key = b"useless_bytes"
+
+    with pytest.raises(KeyOperationError) as error:
+        share_project_private_key(
+            from_user=unituser,
+            to_another=invite1,
+            from_user_token=unituser_token,
+            project=unituser.unit.projects[0],
+        )
+
+    assert "User public key could not be loaded!" in str(error.value)
+
+
+def test_user_key_operation_error_with_decrypt_user_private_key(client):
+    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+    unituser = models.User.query.filter_by(username="unituser").first()
+
+    # Somehow a wrong password has ended up in the encrypted token
+    unituser_token = encrypted_jwt_token(
+        username=unituser.username,
+        sensitive_content="passwor",
+    )
+    with pytest.raises(KeyOperationError) as error:
+        share_project_private_key(
+            from_user=unituser,
+            to_another=invite1,
+            from_user_token=unituser_token,
+            project=unituser.unit.projects[0],
+        )
+
+    assert "User private key could not be decrypted!" in str(error.value)
+
+
+def test_sensitive_content_missing_error(client):
+    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+    unituser = models.User.query.filter_by(username="unituser").first()
+
+    # Somehow the password is missing in the encrypted token
+    unituser_token = encrypted_jwt_token(
+        username=unituser.username,
+        sensitive_content=None,
+    )
+    with pytest.raises(SensitiveContentMissingError) as error:
+        share_project_private_key(
+            from_user=unituser,
+            to_another=invite1,
+            from_user_token=unituser_token,
+            project=unituser.unit.projects[0],
+        )
+
+    assert "Sensitive content is missing in the encrypted token!" in str(error.value)
+
+
+def test_user_key_not_found_error_for_project(client):
+    project_without_keys = models.Project(
+        public_id="random_project_id",
+        title="random project_title",
+        description="This is a random project. ",
+        pi="PI",
+        bucket=f"publicproj-{str(timestamp(ts_format='%Y%m%d%H%M%S'))}-{str(uuid.uuid4())}",
+    )
+
+    # Somehow the key pair for the project is not created or persisted to the database
+
+    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+    unituser = models.User.query.filter_by(username="unituser").first()
+    unituser.unit.projects.append(project_without_keys)
+    dds_web.db.session.commit()
+    unituser_token = encrypted_jwt_token(
+        username=unituser.username,
+        sensitive_content="password",
+    )
+    with pytest.raises(KeyNotFoundError) as error:
+        share_project_private_key(
+            from_user=unituser,
+            to_another=invite1,
+            from_user_token=unituser_token,
+            project=project_without_keys,
+        )
+
+    assert "Unrecoverable key error. Aborting." in str(error.value)
+
+
+def test_user_key_generation(client):
+    user = models.User(username="testuser", password="password")
+    assert user.public_key
+    assert isinstance(serialization.load_der_public_key(user.public_key), RSAPublicKey)
+    assert user.nonce
+    assert user.private_key
+
+
+def test_project_key_generation(client):
+    # Setup is done in conftest.py
+    project = models.Project.query.filter_by(public_id="public_project_id").first()
+    assert project.public_key
+    assert isinstance(X25519PublicKey.from_public_bytes(project.public_key), X25519PublicKey)
+    number_of_unitusers_with_project_key = 0
+    project_user_keys = project.project_user_keys
+    for project_user_key in project_user_keys:
+        if (
+            project_user_key.user_id == "unituser"
+            or project_user_key.user_id == "unituser2"
+            or project_user_key.user_id == "unitadmin"
+        ):
+            number_of_unitusers_with_project_key += 1
+    assert number_of_unitusers_with_project_key == 3
+    user = project_user_keys[0].user
+    assert user.nonce
+    assert user.private_key
+
+
+def test_project_key_sharing(client):
+    # Setup is done in conftest.py
+    project = models.Project.query.filter_by(public_id="public_project_id").first()
+    researchuser = models.User.query.filter_by(username="researchuser").first()
+    project_researchuser_key = models.ProjectUserKeys.query.filter_by(
+        project_id=project.id, user_id=researchuser.username
+    ).first()
+    assert project_researchuser_key
+    assert researchuser.nonce
+    assert researchuser.private_key
+
+    unituser = models.User.query.filter_by(username="unituser").first()
+    project_unituser_key = models.ProjectUserKeys.query.filter_by(
+        project_id=project.id, user_id=unituser.username
+    ).first()
+    assert project_unituser_key
+    assert unituser.nonce
+    assert unituser.private_key
+
+
+def test_delete_user_deletes_project_user_keys(client):
+    """Unit Admin deletes unit user"""
+
+    email_to_delete = "unituser2@mailtrap.io"
+
+    project_unituser2_keys_before_delete = models.ProjectUserKeys.query.filter_by(
+        user_id="unituser2"
+    ).all()
+    assert len(project_unituser2_keys_before_delete) == 5
+
+    response = client.delete(
+        tests.DDSEndpoint.USER_DELETE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
+        json={"email": email_to_delete},
+    )
+    assert response.status_code == http.HTTPStatus.OK
+
+    # Make sure that user was deleted
+    exists = user_from_email(email_to_delete)
+    assert exists is None
+    assert dds_web.utils.email_in_db(email_to_delete) is False
+
+    project_unituser2_keys_after_delete = models.ProjectUserKeys.query.filter_by(
+        user_id="unituser2"
+    ).all()
+    assert len(project_unituser2_keys_after_delete) == 0
+
+
+def test_remove_user_from_project_deletes_project_user_keys(client):
+    """Remove an associated user from a project"""
+
+    username = "researchuser2"
+    email = "researchuser2@mailtrap.io"
+    public_id = "second_public_project_id"
+    user_to_remove = {"email": email}
+    project = models.Project.query.filter_by(public_id=public_id).first()
+    assert project
+    researchuser = models.User.query.filter_by(username=username).first()
+    assert researchuser
+    project_user_keys = models.ProjectUserKeys.query.filter_by(
+        project_id=project.id, user_id=researchuser.username
+    ).all()
+    assert len(project_user_keys) == 1
+
+    response = client.post(
+        tests.DDSEndpoint.REMOVE_USER_FROM_PROJ,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
+        query_string={"project": project.public_id},
+        json=user_to_remove,
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    assert (
+        f"User with email {email} no longer associated with {project.public_id}."
+        in response.json["message"]
+    )
+    project_user_key = models.ProjectUserKeys.query.filter_by(
+        project_id=project.id, user_id=researchuser.username
+    ).first()
+    assert not project_user_key
+
+
+def test_share_project_keys_via_two_invites(client):
+    # this test focuses only on the secure parts related to the following scenario
+
+    # unituser invites a new Unit Personnel
+    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+    temporary_key = generate_invite_key_pair(invite1)
+    invite_token1 = encrypted_jwt_token(
+        username="",
+        sensitive_content=temporary_key.hex(),
+        additional_claims={"inv": invite1.email},
+    )
+    unituser = models.User.query.filter_by(username="unituser").first()
+    unituser.unit.invites.append(invite1)
+    unituser_token = encrypted_jwt_token(
+        username=unituser.username,
+        sensitive_content="password",
+    )
+    for project in unituser.unit.projects:
+        share_project_private_key(
+            from_user=unituser,
+            to_another=invite1,
+            from_user_token=unituser_token,
+            project=project,
+        )
+    dds_web.db.session.commit()
+
+    # ************************************
+
+    # invited Unit Personnel follows the link and registers itself
+    common_user_fields = {
+        "username": "user_not_existing",
+        "password": "Password123",
+        "name": "Test User",
+    }
+    new_user = models.UnitUser(**common_user_fields)
+    invite1.unit.users.append(new_user)
+    new_email = models.Email(email=invite1.email, primary=True)
+    new_user.emails.append(new_email)
+    new_user.active = True
+    dds_web.db.session.add(new_user)
+    verify_and_transfer_invite_to_user(invite_token1, new_user, common_user_fields["password"])
+    for project_invite_key in invite1.project_invite_keys:
+        project_user_key = models.ProjectUserKeys(
+            project_id=project_invite_key.project_id,
+            user_id=new_user.username,
+            key=project_invite_key.key,
+        )
+        dds_web.db.session.add(project_user_key)
+        dds_web.db.session.delete(project_invite_key)
+
+    assert invite1.nonce != new_user.nonce
+    assert invite1.public_key == new_user.public_key
+    assert invite1.private_key != new_user.private_key
+
+    dds_web.db.session.delete(invite1)
+    dds_web.db.session.commit()
+
+    # ************************************
+
+    # new Unit Personnel invites another new Unit Personnel
+    invite2 = models.Invite(email="another_unit_user@mailtrap.io", role="Unit Personnel")
+    invite_token2 = encrypted_jwt_token(
+        username="",
+        sensitive_content=generate_invite_key_pair(invite2).hex(),
+        additional_claims={"inv": invite2.email},
+    )
+    unituser = models.User.query.filter_by(username="user_not_existing").first()
+    unituser.unit.invites.append(invite2)
+    unituser_token = encrypted_jwt_token(
+        username=unituser.username,
+        sensitive_content=common_user_fields["password"],
+    )
+    for project in unituser.unit.projects:
+        share_project_private_key(
+            from_user=unituser,
+            to_another=invite2,
+            from_user_token=unituser_token,
+            project=project,
+        )
+    dds_web.db.session.commit()
+
+    project_invite_keys = invite2.project_invite_keys
+    number_of_asserted_projects = 0
+    for project_invite_key in project_invite_keys:
+        if (
+            project_invite_key.project.public_id == "public_project_id"
+            or project_invite_key.project.public_id == "unused_project_id"
+            or project_invite_key.project.public_id == "restricted_project_id"
+            or project_invite_key.project.public_id == "second_public_project_id"
+            or project_invite_key.project.public_id == "file_testing_project"
+        ):
+            number_of_asserted_projects += 1
+    assert len(project_invite_keys) == number_of_asserted_projects
+    assert len(project_invite_keys) == 5
+
+
+def test_update_user_keys_for_password_change(client):
+    user = models.User(username="randomtestuser", password="password")
+
+    public_key_initial = user.public_key
+    nonce_initial = user.nonce
+    private_key_initial = user.private_key
+    kd_salt_initial = user.kd_salt
+
+    assert public_key_initial
+    assert nonce_initial
+    assert private_key_initial
+    assert kd_salt_initial
+
+    update_user_keys_for_password_change(user, "password", "bogus")
+    user.password = "bogus"
+
+    public_key_after_password_change = user.public_key
+    nonce_after_password_change = user.nonce
+    private_key_after_password_change = user.private_key
+    kd_salt_after_password_change = user.kd_salt
+
+    assert public_key_after_password_change
+    assert nonce_after_password_change
+    assert private_key_after_password_change
+    assert kd_salt_after_password_change
+
+    assert public_key_after_password_change == public_key_initial
+    assert nonce_after_password_change != nonce_initial
+    assert private_key_after_password_change != private_key_initial
+    assert kd_salt_after_password_change != kd_salt_initial
+
+    # It shouldn't matter whichever comes first between set password
+    # and update user keys as the password is not stored in database
+
+    user.password = "password"
+    update_user_keys_for_password_change(user, "bogus", "password")
+
+    public_key_final = user.public_key
+    nonce_final = user.nonce
+    private_key_final = user.private_key
+    kd_salt_final = user.kd_salt
+
+    assert public_key_final
+    assert nonce_final
+    assert private_key_final
+    assert kd_salt_final
+
+    assert public_key_final == public_key_initial
+    assert nonce_final != nonce_initial
+    assert private_key_final != private_key_initial
+    assert kd_salt_final != kd_salt_initial
+
+    assert public_key_after_password_change == public_key_final
+    assert nonce_after_password_change != nonce_final
+    assert private_key_after_password_change != private_key_final
+    assert kd_salt_after_password_change != kd_salt_final

--- a/tests/test_project_user_keys.py
+++ b/tests/test_project_user_keys.py
@@ -40,6 +40,7 @@ def __padding():
 
 
 def verify_list_items_not_equal(lst):
+    """Confirm that none of the items matches another."""
     for a, b in itertools.combinations(lst, 2):
         assert a != b
 

--- a/tests/test_project_user_keys.py
+++ b/tests/test_project_user_keys.py
@@ -1,5 +1,7 @@
 import http
 import uuid
+import argon2
+import itertools
 
 import pytest
 from cryptography.hazmat.primitives import serialization
@@ -37,431 +39,555 @@ def __padding():
     )
 
 
-def test_user_key_setup_error_with_salt(client):
-    # user is created without a password, so salt will be missing
-    user = models.User(username="testuser")
-    with pytest.raises(KeySetupError) as error:
-        generate_user_key_pair(user, "password")
-
-    assert "User keys are not properly setup!" in str(error.value)
+def verify_list_items_not_equal(lst):
+    for a, b in itertools.combinations(lst, 2):
+        assert a != b
 
 
-def test_user_key_setup_error_with_private_key(client):
-    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-    unituser = models.User.query.filter_by(username="unituser").first()
-    unituser_token = encrypted_jwt_token(
-        username=unituser.username,
-        sensitive_content="password",
+def test_derive_key_ok(client):
+    """Test the key derivation with the same settings for argon2."""
+    from dds_web.security.project_user_keys import __derive_key
+    from dds_web.config import Config
+
+    # Get config
+    config = Config()
+
+    # Get user
+    user = models.User.query.first()
+    password = "password"
+
+    # Derive key
+    derived_key_1 = argon2.low_level.hash_secret_raw(
+        secret=password.encode(),
+        salt=user.kd_salt,
+        time_cost=config.ARGON_TIME_COST_KD,
+        memory_cost=config.ARGON_MEMORY_COST_KD,
+        parallelism=config.ARGON_PARALLELISM_KD,
+        hash_len=config.ARGON_HASH_LENGTH_KD,
+        type=config.ARGON_TYPE_KD,
     )
 
-    # Somehow private key has disappeared
-    unituser.private_key = None
-
-    with pytest.raises(KeySetupError) as error:
-        share_project_private_key(
-            from_user=unituser,
-            to_another=invite1,
-            from_user_token=unituser_token,
-            project=unituser.unit.projects[0],
-        )
-
-    assert "User keys are not properly setup!" in str(error.value)
+    derived_key_2 = __derive_key(user, password)
+    assert derived_key_1 == derived_key_2
 
 
-def test_user_key_setup_error_with_nonce(client):
-    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-    unituser = models.User.query.filter_by(username="unituser").first()
-    unituser_token = encrypted_jwt_token(
-        username=unituser.username,
-        sensitive_content="password",
+def test_derive_key_changed_settings(client):
+    """Test the key derivation with changed settings."""
+    from dds_web.security.project_user_keys import __derive_key
+    from dds_web.config import Config
+
+    # Get config
+    config = Config()
+
+    # Get user
+    user = models.User.query.first()
+    password = "password"
+
+    # Derive key - correct
+    derived_key_1 = __derive_key(user, password)
+
+    # Derive key - changed time cost
+    derived_key_2 = argon2.low_level.hash_secret_raw(
+        secret=password.encode(),
+        salt=user.kd_salt,
+        time_cost=3,
+        memory_cost=config.ARGON_MEMORY_COST_KD,
+        parallelism=config.ARGON_PARALLELISM_KD,
+        hash_len=config.ARGON_HASH_LENGTH_KD,
+        type=config.ARGON_TYPE_KD,
+    )
+    verify_list_items_not_equal(lst=[derived_key_1, derived_key_2])
+
+    # Derive key - changed memory cost
+    derived_key_3 = argon2.low_level.hash_secret_raw(
+        secret=password.encode(),
+        salt=user.kd_salt,
+        time_cost=config.ARGON_TIME_COST_KD,
+        memory_cost=0x40000,
+        parallelism=config.ARGON_PARALLELISM_KD,
+        hash_len=config.ARGON_HASH_LENGTH_KD,
+        type=config.ARGON_TYPE_KD,
     )
 
-    # Somehow nonce has disappeared
-    unituser.nonce = None
+    verify_list_items_not_equal(lst=[derived_key_1, derived_key_2, derived_key_3])
 
-    with pytest.raises(KeySetupError) as error:
-        share_project_private_key(
-            from_user=unituser,
-            to_another=invite1,
-            from_user_token=unituser_token,
-            project=unituser.unit.projects[0],
-        )
-
-    assert "User keys are not properly setup!" in str(error.value)
-
-
-def test_user_key_setup_error_with_public_key(client):
-    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-
-    # Somehow the key pair for the invite has not taken place or disappeared
-
-    unituser = models.User.query.filter_by(username="unituser").first()
-    unituser_token = encrypted_jwt_token(
-        username=unituser.username,
-        sensitive_content="password",
-    )
-    with pytest.raises(KeySetupError) as error:
-        share_project_private_key(
-            from_user=unituser,
-            to_another=invite1,
-            from_user_token=unituser_token,
-            project=unituser.unit.projects[0],
-        )
-
-    assert "User keys are not properly setup!" in str(error.value)
-
-
-def test_user_key_operation_error_with_load_user_public_key(client):
-    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-    generate_invite_key_pair(invite1)
-    unituser = models.User.query.filter_by(username="unituser").first()
-    unituser_token = encrypted_jwt_token(
-        username=unituser.username,
-        sensitive_content="password",
+    # Derive key - changed parallelism
+    derived_key_4 = argon2.low_level.hash_secret_raw(
+        secret=password.encode(),
+        salt=user.kd_salt,
+        time_cost=config.ARGON_TIME_COST_KD,
+        memory_cost=config.ARGON_MEMORY_COST_KD,
+        parallelism=4,
+        hash_len=config.ARGON_HASH_LENGTH_KD,
+        type=config.ARGON_TYPE_KD,
     )
 
-    # Somehow the public key of the invite is not the expected public key
-    invite1.public_key = b"useless_bytes"
+    verify_list_items_not_equal(lst=[derived_key_1, derived_key_2, derived_key_3, derived_key_4])
 
-    with pytest.raises(KeyOperationError) as error:
-        share_project_private_key(
-            from_user=unituser,
-            to_another=invite1,
-            from_user_token=unituser_token,
-            project=unituser.unit.projects[0],
-        )
-
-    assert "User public key could not be loaded!" in str(error.value)
-
-
-def test_user_key_operation_error_with_decrypt_user_private_key(client):
-    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-    unituser = models.User.query.filter_by(username="unituser").first()
-
-    # Somehow a wrong password has ended up in the encrypted token
-    unituser_token = encrypted_jwt_token(
-        username=unituser.username,
-        sensitive_content="passwor",
-    )
-    with pytest.raises(KeyOperationError) as error:
-        share_project_private_key(
-            from_user=unituser,
-            to_another=invite1,
-            from_user_token=unituser_token,
-            project=unituser.unit.projects[0],
-        )
-
-    assert "User private key could not be decrypted!" in str(error.value)
-
-
-def test_sensitive_content_missing_error(client):
-    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-    unituser = models.User.query.filter_by(username="unituser").first()
-
-    # Somehow the password is missing in the encrypted token
-    unituser_token = encrypted_jwt_token(
-        username=unituser.username,
-        sensitive_content=None,
-    )
-    with pytest.raises(SensitiveContentMissingError) as error:
-        share_project_private_key(
-            from_user=unituser,
-            to_another=invite1,
-            from_user_token=unituser_token,
-            project=unituser.unit.projects[0],
-        )
-
-    assert "Sensitive content is missing in the encrypted token!" in str(error.value)
-
-
-def test_user_key_not_found_error_for_project(client):
-    project_without_keys = models.Project(
-        public_id="random_project_id",
-        title="random project_title",
-        description="This is a random project. ",
-        pi="PI",
-        bucket=f"publicproj-{str(timestamp(ts_format='%Y%m%d%H%M%S'))}-{str(uuid.uuid4())}",
+    # Derive key - changed hash len
+    derived_key_5 = argon2.low_level.hash_secret_raw(
+        secret=password.encode(),
+        salt=user.kd_salt,
+        time_cost=config.ARGON_TIME_COST_KD,
+        memory_cost=config.ARGON_MEMORY_COST_KD,
+        parallelism=config.ARGON_PARALLELISM_KD,
+        hash_len=16,
+        type=config.ARGON_TYPE_KD,
     )
 
-    # Somehow the key pair for the project is not created or persisted to the database
-
-    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-    unituser = models.User.query.filter_by(username="unituser").first()
-    unituser.unit.projects.append(project_without_keys)
-    dds_web.db.session.commit()
-    unituser_token = encrypted_jwt_token(
-        username=unituser.username,
-        sensitive_content="password",
+    verify_list_items_not_equal(
+        lst=[derived_key_1, derived_key_2, derived_key_3, derived_key_4, derived_key_5]
     )
-    with pytest.raises(KeyNotFoundError) as error:
-        share_project_private_key(
-            from_user=unituser,
-            to_another=invite1,
-            from_user_token=unituser_token,
-            project=project_without_keys,
-        )
 
-    assert "Unrecoverable key error. Aborting." in str(error.value)
-
-
-def test_user_key_generation(client):
-    user = models.User(username="testuser", password="password")
-    assert user.public_key
-    assert isinstance(serialization.load_der_public_key(user.public_key), RSAPublicKey)
-    assert user.nonce
-    assert user.private_key
-
-
-def test_project_key_generation(client):
-    # Setup is done in conftest.py
-    project = models.Project.query.filter_by(public_id="public_project_id").first()
-    assert project.public_key
-    assert isinstance(X25519PublicKey.from_public_bytes(project.public_key), X25519PublicKey)
-    number_of_unitusers_with_project_key = 0
-    project_user_keys = project.project_user_keys
-    for project_user_key in project_user_keys:
-        if (
-            project_user_key.user_id == "unituser"
-            or project_user_key.user_id == "unituser2"
-            or project_user_key.user_id == "unitadmin"
-        ):
-            number_of_unitusers_with_project_key += 1
-    assert number_of_unitusers_with_project_key == 3
-    user = project_user_keys[0].user
-    assert user.nonce
-    assert user.private_key
-
-
-def test_project_key_sharing(client):
-    # Setup is done in conftest.py
-    project = models.Project.query.filter_by(public_id="public_project_id").first()
-    researchuser = models.User.query.filter_by(username="researchuser").first()
-    project_researchuser_key = models.ProjectUserKeys.query.filter_by(
-        project_id=project.id, user_id=researchuser.username
-    ).first()
-    assert project_researchuser_key
-    assert researchuser.nonce
-    assert researchuser.private_key
-
-    unituser = models.User.query.filter_by(username="unituser").first()
-    project_unituser_key = models.ProjectUserKeys.query.filter_by(
-        project_id=project.id, user_id=unituser.username
-    ).first()
-    assert project_unituser_key
-    assert unituser.nonce
-    assert unituser.private_key
-
-
-def test_delete_user_deletes_project_user_keys(client):
-    """Unit Admin deletes unit user"""
-
-    email_to_delete = "unituser2@mailtrap.io"
-
-    project_unituser2_keys_before_delete = models.ProjectUserKeys.query.filter_by(
-        user_id="unituser2"
-    ).all()
-    assert len(project_unituser2_keys_before_delete) == 5
-
-    response = client.delete(
-        tests.DDSEndpoint.USER_DELETE,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
-        json={"email": email_to_delete},
+    # Derive key - changed type
+    derived_key_6 = argon2.low_level.hash_secret_raw(
+        secret=password.encode(),
+        salt=user.kd_salt,
+        time_cost=config.ARGON_TIME_COST_KD,
+        memory_cost=config.ARGON_MEMORY_COST_KD,
+        parallelism=config.ARGON_PARALLELISM_KD,
+        hash_len=config.ARGON_HASH_LENGTH_KD,
+        type=argon2.Type.I,
     )
-    assert response.status_code == http.HTTPStatus.OK
 
-    # Make sure that user was deleted
-    exists = user_from_email(email_to_delete)
-    assert exists is None
-    assert dds_web.utils.email_in_db(email_to_delete) is False
-
-    project_unituser2_keys_after_delete = models.ProjectUserKeys.query.filter_by(
-        user_id="unituser2"
-    ).all()
-    assert len(project_unituser2_keys_after_delete) == 0
-
-
-def test_remove_user_from_project_deletes_project_user_keys(client):
-    """Remove an associated user from a project"""
-
-    username = "researchuser2"
-    email = "researchuser2@mailtrap.io"
-    public_id = "second_public_project_id"
-    user_to_remove = {"email": email}
-    project = models.Project.query.filter_by(public_id=public_id).first()
-    assert project
-    researchuser = models.User.query.filter_by(username=username).first()
-    assert researchuser
-    project_user_keys = models.ProjectUserKeys.query.filter_by(
-        project_id=project.id, user_id=researchuser.username
-    ).all()
-    assert len(project_user_keys) == 1
-
-    response = client.post(
-        tests.DDSEndpoint.REMOVE_USER_FROM_PROJ,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
-        query_string={"project": project.public_id},
-        json=user_to_remove,
+    verify_list_items_not_equal(
+        lst=[
+            derived_key_1,
+            derived_key_2,
+            derived_key_3,
+            derived_key_4,
+            derived_key_5,
+            derived_key_6,
+        ]
     )
-    assert response.status_code == http.HTTPStatus.OK
-    assert (
-        f"User with email {email} no longer associated with {project.public_id}."
-        in response.json["message"]
-    )
-    project_user_key = models.ProjectUserKeys.query.filter_by(
-        project_id=project.id, user_id=researchuser.username
-    ).first()
-    assert not project_user_key
 
 
-def test_share_project_keys_via_two_invites(client):
-    # this test focuses only on the secure parts related to the following scenario
+# def test_user_key_setup_error_with_salt(client):
+#     # user is created without a password, so salt will be missing
+#     user = models.User(username="testuser")
 
-    # unituser invites a new Unit Personnel
-    invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
-    temporary_key = generate_invite_key_pair(invite1)
-    invite_token1 = encrypted_jwt_token(
-        username="",
-        sensitive_content=temporary_key.hex(),
-        additional_claims={"inv": invite1.email},
-    )
-    unituser = models.User.query.filter_by(username="unituser").first()
-    unituser.unit.invites.append(invite1)
-    unituser_token = encrypted_jwt_token(
-        username=unituser.username,
-        sensitive_content="password",
-    )
-    for project in unituser.unit.projects:
-        share_project_private_key(
-            from_user=unituser,
-            to_another=invite1,
-            from_user_token=unituser_token,
-            project=project,
-        )
-    dds_web.db.session.commit()
+#     with pytest.raises(KeySetupError) as error:
+#         generate_user_key_pair(user, "password")
 
-    # ************************************
-
-    # invited Unit Personnel follows the link and registers itself
-    common_user_fields = {
-        "username": "user_not_existing",
-        "password": "Password123",
-        "name": "Test User",
-    }
-    new_user = models.UnitUser(**common_user_fields)
-    invite1.unit.users.append(new_user)
-    new_email = models.Email(email=invite1.email, primary=True)
-    new_user.emails.append(new_email)
-    new_user.active = True
-    dds_web.db.session.add(new_user)
-    verify_and_transfer_invite_to_user(invite_token1, new_user, common_user_fields["password"])
-    for project_invite_key in invite1.project_invite_keys:
-        project_user_key = models.ProjectUserKeys(
-            project_id=project_invite_key.project_id,
-            user_id=new_user.username,
-            key=project_invite_key.key,
-        )
-        dds_web.db.session.add(project_user_key)
-        dds_web.db.session.delete(project_invite_key)
-
-    assert invite1.nonce != new_user.nonce
-    assert invite1.public_key == new_user.public_key
-    assert invite1.private_key != new_user.private_key
-
-    dds_web.db.session.delete(invite1)
-    dds_web.db.session.commit()
-
-    # ************************************
-
-    # new Unit Personnel invites another new Unit Personnel
-    invite2 = models.Invite(email="another_unit_user@mailtrap.io", role="Unit Personnel")
-    invite_token2 = encrypted_jwt_token(
-        username="",
-        sensitive_content=generate_invite_key_pair(invite2).hex(),
-        additional_claims={"inv": invite2.email},
-    )
-    unituser = models.User.query.filter_by(username="user_not_existing").first()
-    unituser.unit.invites.append(invite2)
-    unituser_token = encrypted_jwt_token(
-        username=unituser.username,
-        sensitive_content=common_user_fields["password"],
-    )
-    for project in unituser.unit.projects:
-        share_project_private_key(
-            from_user=unituser,
-            to_another=invite2,
-            from_user_token=unituser_token,
-            project=project,
-        )
-    dds_web.db.session.commit()
-
-    project_invite_keys = invite2.project_invite_keys
-    number_of_asserted_projects = 0
-    for project_invite_key in project_invite_keys:
-        if (
-            project_invite_key.project.public_id == "public_project_id"
-            or project_invite_key.project.public_id == "unused_project_id"
-            or project_invite_key.project.public_id == "restricted_project_id"
-            or project_invite_key.project.public_id == "second_public_project_id"
-            or project_invite_key.project.public_id == "file_testing_project"
-        ):
-            number_of_asserted_projects += 1
-    assert len(project_invite_keys) == number_of_asserted_projects
-    assert len(project_invite_keys) == 5
+#     assert "User keys are not properly setup!" in str(error.value)
 
 
-def test_update_user_keys_for_password_change(client):
-    user = models.User(username="randomtestuser", password="password")
+# def test_user_key_setup_error_with_private_key(client):
+#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+#     unituser = models.User.query.filter_by(username="unituser").first()
+#     unituser_token = encrypted_jwt_token(
+#         username=unituser.username,
+#         sensitive_content="password",
+#     )
 
-    public_key_initial = user.public_key
-    nonce_initial = user.nonce
-    private_key_initial = user.private_key
-    kd_salt_initial = user.kd_salt
+#     # Somehow private key has disappeared
+#     unituser.private_key = None
 
-    assert public_key_initial
-    assert nonce_initial
-    assert private_key_initial
-    assert kd_salt_initial
+#     with pytest.raises(KeySetupError) as error:
+#         share_project_private_key(
+#             from_user=unituser,
+#             to_another=invite1,
+#             from_user_token=unituser_token,
+#             project=unituser.unit.projects[0],
+#         )
 
-    update_user_keys_for_password_change(user, "password", "bogus")
-    user.password = "bogus"
+#     assert "User keys are not properly setup!" in str(error.value)
 
-    public_key_after_password_change = user.public_key
-    nonce_after_password_change = user.nonce
-    private_key_after_password_change = user.private_key
-    kd_salt_after_password_change = user.kd_salt
 
-    assert public_key_after_password_change
-    assert nonce_after_password_change
-    assert private_key_after_password_change
-    assert kd_salt_after_password_change
+# def test_user_key_setup_error_with_nonce(client):
+#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+#     unituser = models.User.query.filter_by(username="unituser").first()
+#     unituser_token = encrypted_jwt_token(
+#         username=unituser.username,
+#         sensitive_content="password",
+#     )
 
-    assert public_key_after_password_change == public_key_initial
-    assert nonce_after_password_change != nonce_initial
-    assert private_key_after_password_change != private_key_initial
-    assert kd_salt_after_password_change != kd_salt_initial
+#     # Somehow nonce has disappeared
+#     unituser.nonce = None
 
-    # It shouldn't matter whichever comes first between set password
-    # and update user keys as the password is not stored in database
+#     with pytest.raises(KeySetupError) as error:
+#         share_project_private_key(
+#             from_user=unituser,
+#             to_another=invite1,
+#             from_user_token=unituser_token,
+#             project=unituser.unit.projects[0],
+#         )
 
-    user.password = "password"
-    update_user_keys_for_password_change(user, "bogus", "password")
+#     assert "User keys are not properly setup!" in str(error.value)
 
-    public_key_final = user.public_key
-    nonce_final = user.nonce
-    private_key_final = user.private_key
-    kd_salt_final = user.kd_salt
 
-    assert public_key_final
-    assert nonce_final
-    assert private_key_final
-    assert kd_salt_final
+# def test_user_key_setup_error_with_public_key(client):
+#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
 
-    assert public_key_final == public_key_initial
-    assert nonce_final != nonce_initial
-    assert private_key_final != private_key_initial
-    assert kd_salt_final != kd_salt_initial
+#     # Somehow the key pair for the invite has not taken place or disappeared
 
-    assert public_key_after_password_change == public_key_final
-    assert nonce_after_password_change != nonce_final
-    assert private_key_after_password_change != private_key_final
-    assert kd_salt_after_password_change != kd_salt_final
+#     unituser = models.User.query.filter_by(username="unituser").first()
+#     unituser_token = encrypted_jwt_token(
+#         username=unituser.username,
+#         sensitive_content="password",
+#     )
+#     with pytest.raises(KeySetupError) as error:
+#         share_project_private_key(
+#             from_user=unituser,
+#             to_another=invite1,
+#             from_user_token=unituser_token,
+#             project=unituser.unit.projects[0],
+#         )
+
+#     assert "User keys are not properly setup!" in str(error.value)
+
+
+# def test_user_key_operation_error_with_load_user_public_key(client):
+#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+#     generate_invite_key_pair(invite1)
+#     unituser = models.User.query.filter_by(username="unituser").first()
+#     unituser_token = encrypted_jwt_token(
+#         username=unituser.username,
+#         sensitive_content="password",
+#     )
+
+#     # Somehow the public key of the invite is not the expected public key
+#     invite1.public_key = b"useless_bytes"
+
+#     with pytest.raises(KeyOperationError) as error:
+#         share_project_private_key(
+#             from_user=unituser,
+#             to_another=invite1,
+#             from_user_token=unituser_token,
+#             project=unituser.unit.projects[0],
+#         )
+
+#     assert "User public key could not be loaded!" in str(error.value)
+
+
+# def test_user_key_operation_error_with_decrypt_user_private_key(client):
+#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+#     unituser = models.User.query.filter_by(username="unituser").first()
+
+#     # Somehow a wrong password has ended up in the encrypted token
+#     unituser_token = encrypted_jwt_token(
+#         username=unituser.username,
+#         sensitive_content="passwor",
+#     )
+#     with pytest.raises(KeyOperationError) as error:
+#         share_project_private_key(
+#             from_user=unituser,
+#             to_another=invite1,
+#             from_user_token=unituser_token,
+#             project=unituser.unit.projects[0],
+#         )
+
+#     assert "User private key could not be decrypted!" in str(error.value)
+
+
+# def test_sensitive_content_missing_error(client):
+#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+#     unituser = models.User.query.filter_by(username="unituser").first()
+
+#     # Somehow the password is missing in the encrypted token
+#     unituser_token = encrypted_jwt_token(
+#         username=unituser.username,
+#         sensitive_content=None,
+#     )
+#     with pytest.raises(SensitiveContentMissingError) as error:
+#         share_project_private_key(
+#             from_user=unituser,
+#             to_another=invite1,
+#             from_user_token=unituser_token,
+#             project=unituser.unit.projects[0],
+#         )
+
+#     assert "Sensitive content is missing in the encrypted token!" in str(error.value)
+
+
+# def test_user_key_not_found_error_for_project(client):
+#     project_without_keys = models.Project(
+#         public_id="random_project_id",
+#         title="random project_title",
+#         description="This is a random project. ",
+#         pi="PI",
+#         bucket=f"publicproj-{str(timestamp(ts_format='%Y%m%d%H%M%S'))}-{str(uuid.uuid4())}",
+#     )
+
+#     # Somehow the key pair for the project is not created or persisted to the database
+
+#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+#     unituser = models.User.query.filter_by(username="unituser").first()
+#     unituser.unit.projects.append(project_without_keys)
+#     dds_web.db.session.commit()
+#     unituser_token = encrypted_jwt_token(
+#         username=unituser.username,
+#         sensitive_content="password",
+#     )
+#     with pytest.raises(KeyNotFoundError) as error:
+#         share_project_private_key(
+#             from_user=unituser,
+#             to_another=invite1,
+#             from_user_token=unituser_token,
+#             project=project_without_keys,
+#         )
+
+#     assert "Unrecoverable key error. Aborting." in str(error.value)
+
+
+# def test_user_key_generation(client):
+#     user = models.User(username="testuser", password="password")
+#     assert user.public_key
+#     assert isinstance(serialization.load_der_public_key(user.public_key), RSAPublicKey)
+#     assert user.nonce
+#     assert user.private_key
+
+
+# def test_project_key_generation(client):
+#     # Setup is done in conftest.py
+#     project = models.Project.query.filter_by(public_id="public_project_id").first()
+#     assert project.public_key
+#     assert isinstance(X25519PublicKey.from_public_bytes(project.public_key), X25519PublicKey)
+#     number_of_unitusers_with_project_key = 0
+#     project_user_keys = project.project_user_keys
+#     for project_user_key in project_user_keys:
+#         if (
+#             project_user_key.user_id == "unituser"
+#             or project_user_key.user_id == "unituser2"
+#             or project_user_key.user_id == "unitadmin"
+#         ):
+#             number_of_unitusers_with_project_key += 1
+#     assert number_of_unitusers_with_project_key == 3
+#     user = project_user_keys[0].user
+#     assert user.nonce
+#     assert user.private_key
+
+
+# def test_project_key_sharing(client):
+#     # Setup is done in conftest.py
+#     project = models.Project.query.filter_by(public_id="public_project_id").first()
+#     researchuser = models.User.query.filter_by(username="researchuser").first()
+#     project_researchuser_key = models.ProjectUserKeys.query.filter_by(
+#         project_id=project.id, user_id=researchuser.username
+#     ).first()
+#     assert project_researchuser_key
+#     assert researchuser.nonce
+#     assert researchuser.private_key
+
+#     unituser = models.User.query.filter_by(username="unituser").first()
+#     project_unituser_key = models.ProjectUserKeys.query.filter_by(
+#         project_id=project.id, user_id=unituser.username
+#     ).first()
+#     assert project_unituser_key
+#     assert unituser.nonce
+#     assert unituser.private_key
+
+
+# def test_delete_user_deletes_project_user_keys(client):
+#     """Unit Admin deletes unit user"""
+
+#     email_to_delete = "unituser2@mailtrap.io"
+
+#     project_unituser2_keys_before_delete = models.ProjectUserKeys.query.filter_by(
+#         user_id="unituser2"
+#     ).all()
+#     assert len(project_unituser2_keys_before_delete) == 5
+
+#     response = client.delete(
+#         tests.DDSEndpoint.USER_DELETE,
+#         headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
+#         json={"email": email_to_delete},
+#     )
+#     assert response.status_code == http.HTTPStatus.OK
+
+#     # Make sure that user was deleted
+#     exists = user_from_email(email_to_delete)
+#     assert exists is None
+#     assert dds_web.utils.email_in_db(email_to_delete) is False
+
+#     project_unituser2_keys_after_delete = models.ProjectUserKeys.query.filter_by(
+#         user_id="unituser2"
+#     ).all()
+#     assert len(project_unituser2_keys_after_delete) == 0
+
+
+# def test_remove_user_from_project_deletes_project_user_keys(client):
+#     """Remove an associated user from a project"""
+
+#     username = "researchuser2"
+#     email = "researchuser2@mailtrap.io"
+#     public_id = "second_public_project_id"
+#     user_to_remove = {"email": email}
+#     project = models.Project.query.filter_by(public_id=public_id).first()
+#     assert project
+#     researchuser = models.User.query.filter_by(username=username).first()
+#     assert researchuser
+#     project_user_keys = models.ProjectUserKeys.query.filter_by(
+#         project_id=project.id, user_id=researchuser.username
+#     ).all()
+#     assert len(project_user_keys) == 1
+
+#     response = client.post(
+#         tests.DDSEndpoint.REMOVE_USER_FROM_PROJ,
+#         headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(client),
+#         query_string={"project": project.public_id},
+#         json=user_to_remove,
+#     )
+#     assert response.status_code == http.HTTPStatus.OK
+#     assert (
+#         f"User with email {email} no longer associated with {project.public_id}."
+#         in response.json["message"]
+#     )
+#     project_user_key = models.ProjectUserKeys.query.filter_by(
+#         project_id=project.id, user_id=researchuser.username
+#     ).first()
+#     assert not project_user_key
+
+
+# def test_share_project_keys_via_two_invites(client):
+#     # this test focuses only on the secure parts related to the following scenario
+
+#     # unituser invites a new Unit Personnel
+#     invite1 = models.Invite(email="new_unit_user@mailtrap.io", role="Unit Personnel")
+#     temporary_key = generate_invite_key_pair(invite1)
+#     invite_token1 = encrypted_jwt_token(
+#         username="",
+#         sensitive_content=temporary_key.hex(),
+#         additional_claims={"inv": invite1.email},
+#     )
+#     unituser = models.User.query.filter_by(username="unituser").first()
+#     unituser.unit.invites.append(invite1)
+#     unituser_token = encrypted_jwt_token(
+#         username=unituser.username,
+#         sensitive_content="password",
+#     )
+#     for project in unituser.unit.projects:
+#         share_project_private_key(
+#             from_user=unituser,
+#             to_another=invite1,
+#             from_user_token=unituser_token,
+#             project=project,
+#         )
+#     dds_web.db.session.commit()
+
+#     # ************************************
+
+#     # invited Unit Personnel follows the link and registers itself
+#     common_user_fields = {
+#         "username": "user_not_existing",
+#         "password": "Password123",
+#         "name": "Test User",
+#     }
+#     new_user = models.UnitUser(**common_user_fields)
+#     invite1.unit.users.append(new_user)
+#     new_email = models.Email(email=invite1.email, primary=True)
+#     new_user.emails.append(new_email)
+#     new_user.active = True
+#     dds_web.db.session.add(new_user)
+#     verify_and_transfer_invite_to_user(invite_token1, new_user, common_user_fields["password"])
+#     for project_invite_key in invite1.project_invite_keys:
+#         project_user_key = models.ProjectUserKeys(
+#             project_id=project_invite_key.project_id,
+#             user_id=new_user.username,
+#             key=project_invite_key.key,
+#         )
+#         dds_web.db.session.add(project_user_key)
+#         dds_web.db.session.delete(project_invite_key)
+
+#     assert invite1.nonce != new_user.nonce
+#     assert invite1.public_key == new_user.public_key
+#     assert invite1.private_key != new_user.private_key
+
+#     dds_web.db.session.delete(invite1)
+#     dds_web.db.session.commit()
+
+#     # ************************************
+
+#     # new Unit Personnel invites another new Unit Personnel
+#     invite2 = models.Invite(email="another_unit_user@mailtrap.io", role="Unit Personnel")
+#     invite_token2 = encrypted_jwt_token(
+#         username="",
+#         sensitive_content=generate_invite_key_pair(invite2).hex(),
+#         additional_claims={"inv": invite2.email},
+#     )
+#     unituser = models.User.query.filter_by(username="user_not_existing").first()
+#     unituser.unit.invites.append(invite2)
+#     unituser_token = encrypted_jwt_token(
+#         username=unituser.username,
+#         sensitive_content=common_user_fields["password"],
+#     )
+#     for project in unituser.unit.projects:
+#         share_project_private_key(
+#             from_user=unituser,
+#             to_another=invite2,
+#             from_user_token=unituser_token,
+#             project=project,
+#         )
+#     dds_web.db.session.commit()
+
+#     project_invite_keys = invite2.project_invite_keys
+#     number_of_asserted_projects = 0
+#     for project_invite_key in project_invite_keys:
+#         if (
+#             project_invite_key.project.public_id == "public_project_id"
+#             or project_invite_key.project.public_id == "unused_project_id"
+#             or project_invite_key.project.public_id == "restricted_project_id"
+#             or project_invite_key.project.public_id == "second_public_project_id"
+#             or project_invite_key.project.public_id == "file_testing_project"
+#         ):
+#             number_of_asserted_projects += 1
+#     assert len(project_invite_keys) == number_of_asserted_projects
+#     assert len(project_invite_keys) == 5
+
+
+# def test_update_user_keys_for_password_change(client):
+#     user = models.User(username="randomtestuser", password="password")
+
+#     public_key_initial = user.public_key
+#     nonce_initial = user.nonce
+#     private_key_initial = user.private_key
+#     kd_salt_initial = user.kd_salt
+
+#     assert public_key_initial
+#     assert nonce_initial
+#     assert private_key_initial
+#     assert kd_salt_initial
+
+#     update_user_keys_for_password_change(user, "password", "bogus")
+#     user.password = "bogus"
+
+#     public_key_after_password_change = user.public_key
+#     nonce_after_password_change = user.nonce
+#     private_key_after_password_change = user.private_key
+#     kd_salt_after_password_change = user.kd_salt
+
+#     assert public_key_after_password_change
+#     assert nonce_after_password_change
+#     assert private_key_after_password_change
+#     assert kd_salt_after_password_change
+
+#     assert public_key_after_password_change == public_key_initial
+#     assert nonce_after_password_change != nonce_initial
+#     assert private_key_after_password_change != private_key_initial
+#     assert kd_salt_after_password_change != kd_salt_initial
+
+#     # It shouldn't matter whichever comes first between set password
+#     # and update user keys as the password is not stored in database
+
+#     user.password = "password"
+#     update_user_keys_for_password_change(user, "bogus", "password")
+
+#     public_key_final = user.public_key
+#     nonce_final = user.nonce
+#     private_key_final = user.private_key
+#     kd_salt_final = user.kd_salt
+
+#     assert public_key_final
+#     assert nonce_final
+#     assert private_key_final
+#     assert kd_salt_final
+
+#     assert public_key_final == public_key_initial
+#     assert nonce_final != nonce_initial
+#     assert private_key_final != private_key_initial
+#     assert kd_salt_final != kd_salt_initial
+
+#     assert public_key_after_password_change == public_key_final
+#     assert nonce_after_password_change != nonce_final
+#     assert private_key_after_password_change != private_key_final
+#     assert kd_salt_after_password_change != kd_salt_final


### PR DESCRIPTION
## Before submitting this PR

1. **Description:** 
    - At the moment, the argon2 settings for the passwords differ from those used when getting the private key. 
    - This PR defines the argon2 settings in config.py: It's not possible to change most settings for the key derivation during retrieval of the private key, but it's possible to set the password settings. If not, they are defaulted to the same as the key derivation.
    - This means that we can try out the different settings for the passwords in an easy way.
    - This should not break anything, since the passwords for all users should be automatically rehashed if the settings are changed in any way. 
        1. User is created during registration: Password is hashed and the full settings and password hash is stored in `user._password_hash` 
        2. User authenticates: No hash is needed because the PasswordHasher uses the settings defined in the password hash; it's not hard coded in the code.
        3. The settings change in some way. 
        4. User authenticates: Authentication still works because nothing is hard coded and the settings are still taken from the hash itself. Rehash is needed though, because the PasswordHasher notices a setting change. `verify_password` then automatically rehashes and saves the new hash. 
2. **Jira task / GitHub issue:** Part of DDS-1439
3. **How to test:**
    1. Start up the api with docker 
    2. Authenticate with `dds auth login`
    3. Change one of the settings in `models.py` in `User.verify_password()`, e.g. `hash_len`
    4. Authenticate again as in step 2 - rehashing should work 
    5. Authenticate again as in step 2 - no rehashing should be done 
    6. Try to download data - should work 
7. **Type of change:** [_Check the relevant boxes in the section below_](#what-type-of-changes-does-the-pr-contain)
8. **Add docstrings and comments to code**, _even if_ you personally think it's obvious.

## What _type of change(s)_ does the PR contain?

<!--
- "Breaking": The change will cause existing functionality to not work as expected.
- Workflow: E.g. a new github action or changes to this PR template. Anything that alters our or the codes workflow.
-->

- [x] New feature
  - [ ] Breaking: _Please describe the reason for the break and how we can fix it._
  - [x] Non-breaking
- [ ] Database change
  - [ ] Migration _included in PR_
  - [ ] Migration _not needed_
- [ ] Bug fix
  - [ ] Breaking: _Please describe the reason for the break and how we can fix it._
  - [ ] Non-breaking
- [ ] Security Alert fix
- [ ] Documentation
- [ ] Tests **(only)**
- [ ] Workflow

## Checklist

- [Sprintlog](../SPRINTLOG.md)
  - [x] Added
  - [ ] Not needed (E.g. PR contains _only_ tests)
- Rebase / Update / Merge _from_ base branch (the branch from which the current is forked)
  - [ ] Done
  - [x] Not needed
- Blocking PRs
  - [ ] Merged
  - [x] No blocking PRs
- PR to `master` branch
  - [ ] Yes: Read [the release instructions](../doc/procedures/new_release.md)
    - [ ] I have followed steps 1-7.
  - [x] No

## Actions / Scans

<!-- Go through all checkboxes. All actions must pass before merging is allowed.-->

- **Black**: Python code formatter. Does not execute. Only tests.
  Run `black .` locally to execute formatting.
  - [x] Passed
- **Prettier**: General code formatter. Our use case: MD and yaml mainly.
  Run `npx prettier --write .` locally to execute formatting.
  - [x] Passed
- **Yamllint**: Linting of yaml files.
  - [x] Passed
- **Tests**: Pytest to verify that functionality works as expected.
  - [ ] New tests added
  - [ ] No new tests
  - [x] Passed
- **CodeQL**: Scan for security vulnerabilities, bugs, errors
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Trivy**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Snyk**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1406"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

