### PR TITLE
Bug: Do not inform if email exists in system when resetting password

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -226,3 +226,4 @@ Please add a _short_ line describing the PR you make, if the PR implements a spe
 - PR template restructured ([#1403](https://github.com/ScilifelabDataCentre/dds_web/pull/1403))
 - Only allow latin1-encodable usernames and passwords ([#1402](https://github.com/ScilifelabDataCentre/dds_web/pull/1402))
 - Bug: Corrected calculation of used storage space in `monitor_usage` command ([#1404](https://github.com/ScilifelabDataCentre/dds_web/pull/1404))
+- Bug: Display same message during password reset independent on if the email address is registered to an account or not ([#1408](https://github.com/ScilifelabDataCentre/dds_web/pull/1408))

--- a/dds_web/forms.py
+++ b/dds_web/forms.py
@@ -126,7 +126,6 @@ class RequestResetForm(flask_wtf.FlaskForm):
         validators=[
             wtforms.validators.DataRequired(),
             wtforms.validators.Email(),
-            utils.email_taken_wtforms(),
         ],
     )
     submit = wtforms.SubmitField("Request Password Reset")

--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -463,7 +463,9 @@ def request_reset_password():
                 flask.current_app.logger.info(f"Sending password reset email to: {form.email.data}")
                 dds_web.utils.send_reset_email(email_row=email, token=token)
             else:
-                flask.flash("Your account is deactivated. You cannot reset your password.", "warning")
+                flask.flash(
+                    "Your account is deactivated. You cannot reset your password.", "warning"
+                )
 
         flask.flash(
             "If the specified email address is registered to a DDS account, "


### PR DESCRIPTION
## Before submitting this PR

1. **Description:** When a user tries to reset the password, the DDS currently displays a different message depending on if the email is registered to a user or not. This means that someone could potentially guess emails during an attempt to hack the system. The message should be identical, which this PR changes. 
2. **Jira task / GitHub issue:** DDS-1508
3. **How to test:**
    1. Start up dds_web locally (docker) 
    2. Go to 127.0.0.1:5000 -- the DDS web interface
    3. Click reset password
    4. Fill in email addresses -- the message should be the same, but the email may or may not be sent. 
        1. An email address that's not registered 
        2. An email address that is registered
        3. An email address that is registered but the user is deactivated - This will still currently display a different message, but it's rare enough (or possibly not used at all at the moment) that it's worth spending time on at the moment. 
5. **Type of change:** [_Check the relevant boxes in the section below_](#what-type-of-changes-does-the-pr-contain)
6. **Add docstrings and comments to code**, _even if_ you personally think it's obvious.

## What _type of change(s)_ does the PR contain?

<!--
- "Breaking": The change will cause existing functionality to not work as expected.
- Workflow: E.g. a new github action or changes to this PR template. Anything that alters our or the codes workflow.
-->

- [ ] New feature
  - [ ] Breaking: _Please describe the reason for the break and how we can fix it._
  - [ ] Non-breaking
- [ ] Database change
  - [ ] Migration _included in PR_
  - [ ] Migration _not needed_
- [x] Bug fix
  - [ ] Breaking: _Please describe the reason for the break and how we can fix it._
  - [x] Non-breaking
- [ ] Security Alert fix
- [ ] Documentation
- [ ] Tests **(only)**
- [ ] Workflow

## Checklist

- [Sprintlog](../SPRINTLOG.md)
  - [x] Added
  - [ ] Not needed (E.g. PR contains _only_ tests)
- Rebase / Update / Merge _from_ base branch (the branch from which the current is forked)
  - [ ] Done
  - [ ] Not needed
- Blocking PRs
  - [ ] Merged
  - [x] No blocking PRs
- PR to `master` branch
  - [ ] Yes: Read [the release instructions](../doc/procedures/new_release.md)
    - [ ] I have followed steps 1-7.
  - [x] No

## Actions / Scans

<!-- Go through all checkboxes. All actions must pass before merging is allowed.-->

- **Black**: Python code formatter. Does not execute. Only tests.
  Run `black .` locally to execute formatting.
  - [x] Passed
- **Prettier**: General code formatter. Our use case: MD and yaml mainly.
  Run `npx prettier --write .` locally to execute formatting.
  - [x] Passed
- **Yamllint**: Linting of yaml files.
  - [x] Passed
- **Tests**: Pytest to verify that functionality works as expected.
  - [ ] New tests added
  - [x] No new tests
  - [ ] Passed
- **CodeQL**: Scan for security vulnerabilities, bugs, errors
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Trivy**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Snyk**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1408"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

