### PR TITLE
Fix sprintlog order

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -273,6 +273,9 @@ _Nothing merged in CLI during this sprint_
 - New version: 2.4.0 ([#1443](https://github.com/ScilifelabDataCentre/dds_web/pull/1443))
 - Bug fix: Web UI project listing fix ([#1445](https://github.com/ScilifelabDataCentre/dds_web/pull/1445))
 - Documentation: Technical Overview, section Creating a Unit in the DDS ([#1449](https://github.com/ScilifelabDataCentre/dds_web/pull/1449))
+
+# 2023-08-07 - 2023-08-18
+
 - Empty endpoint: `ProjectBusy` ([#1446](https://github.com/ScilifelabDataCentre/dds_web/pull/1446))
 - Rename storage-related columns in `Unit` table ([#1447](https://github.com/ScilifelabDataCentre/dds_web/pull/1447))
 - Dependency: Bump `cryptography` to 41.0.3 due to security vulnerability alerts(s) ([#1451](https://github.com/ScilifelabDataCentre/dds_web/pull/1451))


### PR DESCRIPTION
This just fixes the sprintlog dates.

<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1455"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

