### PR TITLE
Add new projectusers row when giving project access

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -296,3 +296,4 @@ _Nothing merged in CLI during this sprint_
 
 - Only return date (not time) from `Statistics` endpoint ([#1456](https://github.com/ScilifelabDataCentre/dds_web/pull/1456))
 - Set `sto2*` columns in `Unit` table to nullable ([#1456](https://github.com/ScilifelabDataCentre/dds_web/pull/1462))
+- Bug fixed: Row in `ProjectUsers` should also be added if it doesn't exist when giving Researcher access to a specific project ([#1464](https://github.com/ScilifelabDataCentre/dds_web/pull/1464))

--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -96,8 +96,7 @@ def setup_logging(app):
                     "class": "logging.handlers.RotatingFileHandler",
                     "maxBytes": app.config.get("LOG_MAX_SIZE"),
                     "backupCount": app.config.get("LOG_BACKUP_COUNT"),
-                    "filename": pathlib.Path(app.config.get("LOGS_DIR"))
-                    / pathlib.Path("actions.log"),
+                    "filename": pathlib.Path(app.config.get("LOGS_DIR")) / pathlib.Path("actions.log"),
                     "formatter": "default",
                 },
                 "console": {

--- a/dds_web/__init__.py
+++ b/dds_web/__init__.py
@@ -96,7 +96,8 @@ def setup_logging(app):
                     "class": "logging.handlers.RotatingFileHandler",
                     "maxBytes": app.config.get("LOG_MAX_SIZE"),
                     "backupCount": app.config.get("LOG_BACKUP_COUNT"),
-                    "filename": pathlib.Path(app.config.get("LOGS_DIR")) / pathlib.Path("actions.log"),
+                    "filename": pathlib.Path(app.config.get("LOGS_DIR"))
+                    / pathlib.Path("actions.log"),
                     "formatter": "default",
                 },
                 "console": {

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -911,6 +911,20 @@ class ProjectAccess(flask_restful.Resource):
                         project_id=proj.id, user_id=user.username
                     ).one_or_none()
                     if not project_keys_row:
+                        # Make sure that Researchers are also listed in project users
+                        if (
+                            user.role == "Researcher"
+                            and not models.ProjectUsers.query.filter_by(
+                                project_id=proj.id, user_id=user.username
+                            ).one_or_none()
+                        ):
+                            # New row in association table
+                            new_projectuser_row = models.ProjectUsers(
+                                project_id=proj.id, user_id=user.username
+                            )
+                            # Append association -- only one required, not both ways
+                            proj.researchusers.append(new_projectuser_row)
+
                         share_project_private_key(
                             from_user=current_user,
                             to_another=user,

--- a/dds_web/security/project_user_keys.py
+++ b/dds_web/security/project_user_keys.py
@@ -127,6 +127,7 @@ def share_project_private_key(
 
 
 def __init_and_append_project_user_key(user, project, project_private_key):
+    """Create a new row in ProjectUserKeys for specific user and project."""
     project_user_key = models.ProjectUserKeys(
         project_id=project.id,
         user_id=user.username,

--- a/tests/test_project_access.py
+++ b/tests/test_project_access.py
@@ -483,6 +483,6 @@ def test_fix_access_unitadmin_valid_email_researcher_no_projectuser_row(client):
 
     # Verify that the projectuserkey row is fixed
     user_project_key_row = models.ProjectUserKeys.query.filter_by(
-        project_id=project.id, user_id="unituser"
+        project_id=project.id, user_id="researchuser"
     ).first()
     assert user_project_key_row

--- a/tests/test_project_access.py
+++ b/tests/test_project_access.py
@@ -460,7 +460,7 @@ def test_fix_access_unitadmin_valid_email_researcher_no_projectuser_row(client):
 
     # Delete projectuser row and verify that it's deleted for user
     _ = delete_project_user(
-        project="public_project_id", user_id="researcher", table_to_use=models.ProjectUsers
+        project_id="public_project_id", user_id="researcher", table_to_use=models.ProjectUsers
     )
     # project_users_row = models.ProjectUsers.query.filter_by(
     #     project_id=project.id, user_id="researchuser"

--- a/tests/test_project_access.py
+++ b/tests/test_project_access.py
@@ -18,7 +18,8 @@ proj_query = {"project": "public_project_id"}
 
 # UTILITY FUNCTIONS ############################################################ UTILITY FUNCTIONS #
 
-def delete_project_user(project_id,user_id):
+
+def delete_project_user(project_id, user_id):
     # Get project from database
     project = models.Project.query.filter_by(public_id=project_id).one_or_none()
     assert project
@@ -36,6 +37,7 @@ def delete_project_user(project_id,user_id):
     assert not user_project_key_row
 
     return project
+
 
 # TESTS #################################################################################### TESTS #
 
@@ -432,7 +434,9 @@ def test_fix_access_unitadmin_valid_email_unituser(client):
 def test_fix_access_unitadmin_valid_email_unituser_no_project(client):
     """Unit Admin giving access to unituser - ok. No project."""
     # Remove ProjectUserKeys row for specific project and user
-    project: models.Project = delete_project_user(project_id="public_project_id", user_id="unituser")
+    project: models.Project = delete_project_user(
+        project_id="public_project_id", user_id="unituser"
+    )
 
     # Fix access for user with no project specified
     token = tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client)
@@ -453,7 +457,9 @@ def test_fix_access_unitadmin_valid_email_unituser_no_project(client):
 def test_fix_access_unitadmin_valid_email_researcher_no_projectuser_row(client):
     """Unit Admin giving access to researcher where there is no row in ProjectUsers table."""
     # Remove ProjectUserKeys row for specific project and user
-    project: models.Project = delete_project_user(project_id="public_project_id", user_id="researchuser")
+    project: models.Project = delete_project_user(
+        project_id="public_project_id", user_id="researchuser"
+    )
 
     # Delete projectuser row and verify that it's deleted for user
     project_users_row = models.ProjectUsers.query.filter_by(

--- a/tests/test_project_access.py
+++ b/tests/test_project_access.py
@@ -442,7 +442,7 @@ def test_fix_access_unitadmin_valid_email_unituser_no_project(client):
 
 
 def test_fix_access_unitadmin_valid_email_researcher_no_projectuser_row(client):
-    """Unit Admin giving access to researcher where"""
+    """Unit Admin giving access to researcher where there is no row in ProjectUsers table."""
     # Get project from database
     project = models.Project.query.filter_by(public_id="public_project_id").one_or_none()
     assert project

--- a/tests/test_project_access.py
+++ b/tests/test_project_access.py
@@ -471,7 +471,7 @@ def test_fix_access_unitadmin_valid_email_researcher_no_projectuser_row(client):
     ).first()
     assert not project_users_row
 
-    # Fix access for user with no project specified
+    # Fix access for user, project specified
     token = tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client)
     response = client.post(
         tests.DDSEndpoint.PROJECT_ACCESS,

--- a/tests/test_project_access.py
+++ b/tests/test_project_access.py
@@ -462,16 +462,6 @@ def test_fix_access_unitadmin_valid_email_researcher_no_projectuser_row(client):
     _ = delete_project_user(
         project_id="public_project_id", user_id="researcher", table_to_use=models.ProjectUsers
     )
-    # project_users_row = models.ProjectUsers.query.filter_by(
-    #     project_id=project.id, user_id="researchuser"
-    # ).first()
-    # if project_users_row:
-    #     db.session.delete(project_users_row)
-    #     db.session.commit()
-    # project_users_row = models.ProjectUsers.query.filter_by(
-    #     project_id=project.id, user_id="researchuser"
-    # ).first()
-    # assert not project_users_row
 
     # Fix access for user, project specified
     token = tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client)


### PR DESCRIPTION
## Before submitting this PR

1. **Description:** When making a request to `ProjectAccess` endpoint, the code does not check if the user is listed in the `ProjectUsers` table (if they're a researcher) and instead only adds a new row in `ProjectUserKeys` if one is missing. This means that users can technically have access to projects (because they have a row in `ProjectUserKeys` where the project keys are encrypted and defined) but they are not listed in the project users (because there is no row in `ProjectUsers`) and therefore the API thinks that they do not have access. A feature discussion point is of course if we really need the two separate tables, but for the forseeable future we need to make sure that one is not added without the other at least. This PR adds this fix. 
2. **Jira task / GitHub issue:** DDS-1660
3. **How to test:** _Add information on how someone could manually test this functionality. As detailed as possible._
4. **Type of change:** [_Check the relevant boxes in the section below_](#what-type-of-changes-does-the-pr-contain)
5. **Add docstrings and comments to code**, _even if_ you personally think it's obvious.

## What _type of change(s)_ does the PR contain?

<!--
- "Breaking": The change will cause existing functionality to not work as expected.
- Workflow: E.g. a new github action or changes to this PR template. Anything that alters our or the codes workflow.
-->

- [ ] New feature
  - [ ] Breaking: _Please describe the reason for the break and how we can fix it._
  - [ ] Non-breaking
- [ ] Database change
  - [ ] Migration _included in PR_
  - [ ] Migration _not needed_
- [x] Bug fix
  - [ ] Breaking: _Please describe the reason for the break and how we can fix it._
  - [x] Non-breaking
- [ ] Security Alert fix
- [ ] Documentation
- [ ] Tests **(only)**
- [ ] Workflow

## Checklist

- [Sprintlog](../SPRINTLOG.md)
  - [x] Added
  - [ ] Not needed (E.g. PR contains _only_ tests)
- Rebase / Update / Merge _from_ base branch (the branch from which the current is forked)
  - [ ] Done
  - [x] Not needed
- Blocking PRs
  - [ ] Merged
  - [x] No blocking PRs
- PR to `master` branch
  - [ ] Yes: Read [the release instructions](https://github.com/ScilifelabDataCentre/dds_web/blob/master/doc/procedures/new_release.md)
    - [ ] I have followed steps 1-8.
  - [x] No

## Actions / Scans

<!-- Go through all checkboxes. All actions must pass before merging is allowed.-->

- **Black**: Python code formatter. Does not execute. Only tests.
  Run `black .` locally to execute formatting.
  - [x] Passed
- **Prettier**: General code formatter. Our use case: MD and yaml mainly.
  Run `npx prettier --write .` locally to execute formatting.
  - [x] Passed
- **Yamllint**: Linting of yaml files.
  - [x] Passed
- **Tests**: Pytest to verify that functionality works as expected.
  - [x] New tests added
  - [ ] No new tests
  - [x] Passed
- **CodeQL**: Scan for security vulnerabilities, bugs, errors
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Trivy**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed
- **Snyk**: Security scanner
  - [ ] New alerts: _Go through them and either fix, dismiss och ignore. Add reasoning in items below._
  - [ ] Alerts fixed: _What?_
  - [ ] Alerts ignored / dismissed: _Why?_
  - [x] Passed


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1464"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

