### PR TITLE
Added sto4_start_time column to be initialized on unit creation

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -300,3 +300,4 @@ _Nothing merged in CLI during this sprint_
 - Dependency: Bump `MariaDB` to LTS version 10.11.5 ([#1465](https://github.com/ScilifelabDataCentre/dds_web/pull/1465))
 - Bug fixed: Row in `ProjectUsers` should also be added if it doesn't exist when giving Researcher access to a specific project ([#1464](https://github.com/ScilifelabDataCentre/dds_web/pull/1464))
 - Workflow: Update PR template and clarify sections ([#1467](https://github.com/ScilifelabDataCentre/dds_web/pull/1467))
+- Column `sto4_start_time` is automatically set when the create-unit command is run ([#1668])(https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1668)

--- a/dds_web/commands.py
+++ b/dds_web/commands.py
@@ -132,6 +132,7 @@ def create_new_unit(
         external_display_name=external_display_name,
         contact_email=contact_email,
         internal_ref=internal_ref or public_id,
+	sto4_start_time=current_time(),
         sto4_endpoint=safespring_endpoint,
         sto4_name=safespring_name,
         sto4_access=safespring_access,
@@ -140,7 +141,6 @@ def create_new_unit(
         days_in_expired=days_in_expired,
         quota=quota,
         warning_level=warn_at,
-        sto4_start_time=current_time(),
     )
     db.session.add(new_unit)
     db.session.commit()

--- a/dds_web/commands.py
+++ b/dds_web/commands.py
@@ -132,7 +132,7 @@ def create_new_unit(
         external_display_name=external_display_name,
         contact_email=contact_email,
         internal_ref=internal_ref or public_id,
-	sto4_start_time=current_time(),
+        sto4_start_time=current_time(),
         sto4_endpoint=safespring_endpoint,
         sto4_name=safespring_name,
         sto4_access=safespring_access,

--- a/dds_web/commands.py
+++ b/dds_web/commands.py
@@ -107,7 +107,7 @@ def create_new_unit(
     """
     from dds_web.database import models
     from dds_web.utils import current_time
-    
+
     error_message = ""
     if len(public_id) > 50:
         error_message = "The 'public_id' can be a maximum of 50 characters"
@@ -140,7 +140,7 @@ def create_new_unit(
         days_in_expired=days_in_expired,
         quota=quota,
         warning_level=warn_at,
-        sto4_start_time = current_time()
+        sto4_start_time=current_time(),
     )
     db.session.add(new_unit)
     db.session.commit()

--- a/dds_web/commands.py
+++ b/dds_web/commands.py
@@ -106,7 +106,8 @@ def create_new_unit(
     https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
     """
     from dds_web.database import models
-
+    from dds_web.utils import current_time
+    
     error_message = ""
     if len(public_id) > 50:
         error_message = "The 'public_id' can be a maximum of 50 characters"
@@ -139,6 +140,7 @@ def create_new_unit(
         days_in_expired=days_in_expired,
         quota=quota,
         warning_level=warn_at,
+        sto4_start_time = current_time()
     )
     db.session.add(new_unit)
     db.session.commit()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -272,6 +272,11 @@ def test_create_new_unit_success(client, runner, capfd: LogCaptureFixture) -> No
     assert new_unit.quota == correct_unit["quota"]
     assert new_unit.warning_level
 
+    # check for the atributes that should not be setted up
+    assert not new_unit.sto2_endpoint
+    assert not new_unit.sto2_name
+    assert not new_unit.sto2_access
+    assert not new_unit.sto2_secret
 
 # update_unit
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -252,6 +252,9 @@ def test_create_new_unit_success(client, runner, capfd: LogCaptureFixture) -> No
     _, err = capfd.readouterr()
     assert f"Unit '{correct_unit['name']}' created" in err
 
+    new_unit = db.session.query(models.Unit).filter(models.Unit.name == correct_unit["name"]).one_or_none()
+
+    assert new_unit.sto4_start_time
 
 # update_unit
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -278,6 +278,7 @@ def test_create_new_unit_success(client, runner, capfd: LogCaptureFixture) -> No
     assert not new_unit.sto2_access
     assert not new_unit.sto2_secret
 
+
 # update_unit
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -272,12 +272,6 @@ def test_create_new_unit_success(client, runner, capfd: LogCaptureFixture) -> No
     assert new_unit.quota == correct_unit["quota"]
     assert new_unit.warning_level
 
-    # check for the atributes that should not be setted up
-    assert not new_unit.sto2_endpoint
-    assert not new_unit.sto2_name
-    assert not new_unit.sto2_access
-    assert not new_unit.sto2_secret
-
 
 # update_unit
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -252,9 +252,12 @@ def test_create_new_unit_success(client, runner, capfd: LogCaptureFixture) -> No
     _, err = capfd.readouterr()
     assert f"Unit '{correct_unit['name']}' created" in err
 
-    new_unit = db.session.query(models.Unit).filter(models.Unit.name == correct_unit["name"]).one_or_none()
+    new_unit = (
+        db.session.query(models.Unit).filter(models.Unit.name == correct_unit["name"]).one_or_none()
+    )
 
     assert new_unit.sto4_start_time
+
 
 # update_unit
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -256,7 +256,21 @@ def test_create_new_unit_success(client, runner, capfd: LogCaptureFixture) -> No
         db.session.query(models.Unit).filter(models.Unit.name == correct_unit["name"]).one_or_none()
     )
 
+    # Check that the different attributes have been set up
+
+    assert new_unit.public_id == correct_unit["public_id"]
+    assert new_unit.external_display_name == correct_unit["external_display_name"]
+    assert new_unit.contact_email == correct_unit["contact_email"]
+    assert new_unit.internal_ref
     assert new_unit.sto4_start_time
+    assert new_unit.sto4_endpoint == correct_unit["safespring_endpoint"]
+    assert new_unit.sto4_name == correct_unit["safespring_name"]
+    assert new_unit.sto4_access == correct_unit["safespring_access"]
+    assert new_unit.sto4_secret == correct_unit["safespring_secret"]
+    assert new_unit.days_in_available
+    assert new_unit.days_in_expired
+    assert new_unit.quota == correct_unit["quota"]
+    assert new_unit.warning_level
 
 
 # update_unit


### PR DESCRIPTION
## Read this before submitting the PR

## 1. Description / Summary

Now the column _Sto4_Start_time_ will automatically be set in the _Units_ table when the create-unit command is run. Instead of having to run the upgrade unit.

## 2. Jira task / GitHub issue

https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1668

## 3. Type of change

What _type of change(s)_ does the PR contain?

**Check the relevant boxes below. For an explanation of the different sections, enter edit mode of this PR description template.**

- [ ] New feature
  - [ ] Breaking: _Why / How? Add info here._ <!-- Should be checked if the changes in this PR will cause existing functionality to not work as expected. E.g. with the master branch of the `dds_cli` -->
  - [ ] Non-breaking <!-- Should be checked if the changes will not cause existing functionality to fail. "Non-breaking" is just an addition of a new feature. -->
- [ ] Database change: _Remember the to include a new migration version, **or** explain here why it's not needed._ <!-- Should be checked when you've changed something in `models.py`. For a guide on how to add the a new migration version, look at the "Database changes" section in the README.md. -->
- [x] Bug fix <!-- Should be checked when a bug is fixed in existing functionality. If the bug fix also is a breaking change (see above), add info about that beside this check box. -->
- [ ] Security Alert fix <!-- Should be checked if the PR attempts to solve a security vulnerability, e.g. reported by the "Security" tab in the repo. -->
- [ ] Documentation <!-- Should be checked if the PR adds or updates documentation such as e.g. Technical Overview or a architecture decision (dds_web/doc/architecture/decisions.) -->
- [ ] Workflow <!-- Should be checked if the PR includes a change in e.g. the github actions files (dds_web/.github/*) or another type of workflow change. Anything that alters our or the codes workflow. -->
- [ ] Tests **only** <!-- Should only be checked if the PR only contains tests, none of the other types of changes listed above. -->

## 4. Additional information

- [x] [Sprintlog](../SPRINTLOG.md) <!-- Add a row at the bottom of the SPRINTLOG.md file (not needed if PR contains only tests). Follow the format of previous rows. If the PR is the first in a new sprint, add a new sprint header row (follow the format of previous sprints). -->
- [ ] Blocking PRs <!-- Should be checked if there are blocking PRs or other tasks that need to be merged prior to this. Add link to PR or Jira card if this is the case. -->
  - [ ] Merged <!-- Should be checked if the "Blocking PRs" box was checked AND all blocking PRs have been merged / fixed. -->
- [ ] PR to `master` branch: \_If checked, read [the release instructions](../doc/procedures/new_release.md) <!-- Check this if the PR is made to the `master` branch. Only the `dev` branch should be doing this. -->
  - [ ] I have followed steps 1-8. <!-- Should be checked if the "PR to `master` branch" box is checked AND the specified steps in the release instructions have been followed. -->

## 5. Actions / Scans

_Check the boxes when the specified checks have passed._

**For information on what the different checks do and how to fix it if they're failing, enter edit mode of this description or go to the [PR template](../.github/pull_request_template.md).**

- [x] **Black**
<!--
  What: Python code formatter.
  How to fix: Run `black .` locally to execute formatting.
-->
- [x] **Prettier**
<!--
  What: General code formatter. Our use case: MD and yaml mainly.
  How to fix: Run npx prettier --write . locally to execute formatting.
-->
- [x] **Yamllint**
<!--
  What: Linting of yaml files.
  How to fix: Manually fix any errors locally.
-->
- [x] **Tests**
<!--
  What: Pytest to verify that functionality works as expected.
  How to fix: Manually fix any errors locally. Follow the instructions in the "Run tests" section of the README.md to run the tests locally.
  Additional info: The PR should ALWAYS include new tests or fixed tests when there are code changes. When pytest action has finished, it will post a codecov report; Look at this report and verify the files you have changed are listed. "90% <100.00%> (+0.8%)" means "Tests cover 90% of the changed file, <100 % of this PR's code changes are tested>, and (the code changes and added tests increased the overall test coverage with 0.8%)
-->
- [x] **CodeQL**
<!--
  What: Scan for security vulnerabilities, bugs, errors.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [x] **Trivy**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [x] **Snyk**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->


<a href="https://gitpod.io/#https://github.com/ScilifelabDataCentre/dds_web/pull/1469"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

