### PR TITLE
Dds 1691 -- New API endpoint to extend the deadline: `ProjectStatus.patch`

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -314,3 +314,4 @@ _Nothing merged in CLI during this sprint_
 - Use full DDS name in MOTD email subject ([#1477](https://github.com/ScilifelabDataCentre/dds_web/pull/1477))
 - Add flag --verify-checksum to the comand in email template ([#1478])(https://github.com/ScilifelabDataCentre/dds_web/pull/1478)
 - Improved email layout; Highlighted information and commands when project is released ([#1479])(https://github.com/ScilifelabDataCentre/dds_web/pull/1479)
+- Added new API endpoint ProjectStatus.patch to extend the deadline ([#1480])(https://github.com/ScilifelabDataCentre/dds_web/pull/1480)

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -314,4 +314,7 @@ _Nothing merged in CLI during this sprint_
 - Use full DDS name in MOTD email subject ([#1477](https://github.com/ScilifelabDataCentre/dds_web/pull/1477))
 - Add flag --verify-checksum to the comand in email template ([#1478])(https://github.com/ScilifelabDataCentre/dds_web/pull/1478)
 - Improved email layout; Highlighted information and commands when project is released ([#1479])(https://github.com/ScilifelabDataCentre/dds_web/pull/1479)
+
+# 2023-10-16 - 2023-10-27
+
 - Added new API endpoint ProjectStatus.patch to extend the deadline ([#1480])(https://github.com/ScilifelabDataCentre/dds_web/pull/1480)

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -271,7 +271,7 @@ class ProjectStatus(flask_restful.Resource):
                 # wont change again -> error
                 if project.times_expired >= 2:
                     raise DDSArgumentError(
-                        "Project availability limit: Project cannot be made Available any more times"
+                        "Project availability limit: The maximun number of changes in data availability has been reached."
                     )
                 try:
                     # add a fake expire status to mimick a re-release in order to have an udpated deadline

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -203,6 +203,13 @@ class ProjectStatus(flask_restful.Resource):
         # Get json input from request
         json_input = flask.request.get_json(silent=True)  # Already checked by json_required
 
+        # the status has changed at least two times,
+        # next time the project expires it wont change again -> error
+        if project.times_expired >= 2:
+            raise DDSArgumentError(
+                "Project availability limit: The maximun number of changes in data availability has been reached."
+            )
+
         # Operation must be confirmed by the user - False by default
         confirmed_operation = json_input.get("confirmed", False)
         if not isinstance(confirmed_operation, bool):
@@ -266,12 +273,6 @@ class ProjectStatus(flask_restful.Resource):
                 if new_deadline_in + current_deadline > 90:
                     raise DDSArgumentError(
                         message=f"You requested the deadline to be extended with {new_deadline_in} days (from {current_deadline}), giving a new total deadline of {new_deadline_in + current_deadline} days. The new deadline needs to be less than (or equal to) 90 days."
-                    )
-                # the dealine has changed at least two times, next time it expires
-                # wont change again -> error
-                if project.times_expired >= 2:
-                    raise DDSArgumentError(
-                        "Project availability limit: The maximun number of changes in data availability has been reached."
                     )
                 try:
                     # add a fake expire status to mimick a re-release in order to have an udpated deadline

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -247,7 +247,7 @@ class ProjectStatus(flask_restful.Resource):
             # some variable definition
             curr_date = dds_web.utils.current_time()
             send_email = False
-            default_unit_days = project.responsible_unit.days_in_expired
+            default_unit_days = project.responsible_unit.days_in_available
 
             # Update the deadline functionality
             if new_deadline_in:

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -228,10 +228,10 @@ class ProjectStatus(flask_restful.Resource):
                 )
             )
 
-        self.set_busy(project=project, busy=True)
-
         # Extend deadline
         try:
+            self.set_busy(project=project, busy=True)
+
             new_deadline_in = json_input.get(
                 "new_deadline_in", None
             )  # if not provided --> is None -> deadline is not updated

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -271,7 +271,7 @@ class ProjectStatus(flask_restful.Resource):
                 except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.SQLAlchemyError) as err:
                     flask.current_app.logger.exception("Failed to extend deadline")
                     db.session.rollback()
-                    raise err
+                    raise
 
                 return_message = f"{project.public_id} has been given a new deadline"
 

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -209,6 +209,7 @@ class ProjectStatus(flask_restful.Resource):
             raise DDSArgumentError(message="`confirmed` is a boolean value: True or False.")
         if not confirmed_operation:
             warning_message = "Operation must be confirmed before proceding."
+            # When not confirmed, return information about the project
             project_info = ProjectInfo().get()
             project_status = self.get()
             json_returned = {
@@ -228,10 +229,10 @@ class ProjectStatus(flask_restful.Resource):
                 )
             )
 
+        self.set_busy(project=project, busy=True)
+
         # Extend deadline
         try:
-            self.set_busy(project=project, busy=True)
-
             new_deadline_in = json_input.get(
                 "new_deadline_in", None
             )  # if not provided --> is None -> deadline is not updated

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -208,7 +208,15 @@ class ProjectStatus(flask_restful.Resource):
             raise DDSArgumentError(message="`confirmed` is a boolean value: True or False.")
         if not confirmed_operation:
             warning_message = "Operation must be confirmed before proceding."
-            return {"warning": warning_message}
+            project_info = ProjectInfo().get()
+            project_status = self.get()
+            json_returned = {
+                **project_info,
+                "project_status": project_status,
+                "warning": warning_message,
+                "default_unit_days": project.responsible_unit.days_in_expired,
+            }
+            return json_returned
 
         # Cannot change project status if project is busy
         if project.busy:

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -233,7 +233,7 @@ class ProjectStatus(flask_restful.Resource):
                 # deadline can only be extended from Available
                 if not project.current_status == "Available":
                     raise DDSArgumentError(
-                        "you can only extend the deadline for a project that has the status Available."
+                        "You can only extend the deadline for a project that has the status 'Available'."
                     )
 
                 new_deadline_in = json_input.get("new_deadline_in")

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -273,7 +273,7 @@ class ProjectStatus(flask_restful.Resource):
                     db.session.commit()
 
                 except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.SQLAlchemyError) as err:
-                    flask.current_app.logger.exception(err)
+                    flask.current_app.logger.exception("Failed to extend deadline")
                     db.session.rollback()
                     raise err
 

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -246,7 +246,7 @@ class ProjectStatus(flask_restful.Resource):
                     )
                 if new_deadline_in + current_deadline > 90:
                     raise DDSArgumentError(
-                        message="The new deadline needs to be less than (or equal to) 90 days."
+                        message=f"You requested the deadline to be extended with {new_deadline_in} days (from {current_deadline}), giving a new total deadline of {new_deadline_in + current_deadline} days. The new deadline needs to be less than (or equal to) 90 days."
                     )
 
                 try:

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -299,7 +299,7 @@ class ProjectStatus(flask_restful.Resource):
                     raise
 
                 return_message = (
-                    f"{project.public_id} has been given a new deadline. "
+                    f"The project '{project.public_id}' has been given a new deadline. "
                     f"An e-mail notification has{' not ' if not send_email else ' '}been sent."
                 )
             else:

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -243,10 +243,6 @@ class ProjectStatus(flask_restful.Resource):
                     raise DDSArgumentError(
                         message="No new deadline provived, cannot perform operation."
                     )
-                if current_deadline > 10:
-                    raise DDSArgumentError(
-                        message=f"There are still {current_deadline} days left, it is not possible to extend deadline yet."
-                    )
                 if new_deadline_in + current_deadline > 90:
                     raise DDSArgumentError(
                         message="The new deadline needs to be less than (or equal to) 90 days."

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -243,7 +243,7 @@ class ProjectStatus(flask_restful.Resource):
                     raise DDSArgumentError(
                         message="The deadline atribute passed should be of type Int (i.e a number)."
                     )
-                
+
                 # it shouldnt surpass 90 days
                 current_deadline = (project.current_deadline - curr_date).days
                 if new_deadline_in + current_deadline > 90:

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -216,6 +216,7 @@ class ProjectStatus(flask_restful.Resource):
                 **project_info,
                 "project_status": project_status,
                 "warning": warning_message,
+                "default_unit_days": project.responsible_unit.days_in_expired,
             }
             return json_returned
 

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -207,7 +207,7 @@ class ProjectStatus(flask_restful.Resource):
         # next time the project expires it wont change again -> error
         if project.times_expired >= 2:
             raise DDSArgumentError(
-                "Project availability limit: The maximun number of changes in data availability has been reached."
+                "Project availability limit: The maximum number of changes in data availability has been reached."
             )
 
         # Operation must be confirmed by the user - False by default

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -223,7 +223,7 @@ class ProjectStatus(flask_restful.Resource):
                 **project_info,
                 "project_status": project_status,
                 "warning": warning_message,
-                "default_unit_days": project.responsible_unit.days_in_expired,
+                "default_unit_days": project.responsible_unit.days_in_available,
             }
             return json_returned
 

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -216,7 +216,6 @@ class ProjectStatus(flask_restful.Resource):
                 **project_info,
                 "project_status": project_status,
                 "warning": warning_message,
-                "default_unit_days": project.responsible_unit.days_in_expired,
             }
             return json_returned
 

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -202,7 +202,7 @@ class ProjectStatus(flask_restful.Resource):
         # Get json input from request
         json_input = flask.request.get_json(silent=True)  # Already checked by json_required
 
-        # false by default - operation must be confirmed by the user
+        # Operation must be confirmed by the user - False by default
         confirmed_operation = json_input.get("confirmed", False)
         if not isinstance(confirmed_operation, bool):
             raise DDSArgumentError(message="`confirmed` is a boolean value: True or False.")

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -252,11 +252,6 @@ class ProjectStatus(flask_restful.Resource):
                         message="The new deadline needs to be less than (or equal to) 90 days."
                     )
 
-                if project.times_expired > 2:
-                    raise DDSArgumentError(
-                        "Project availability limit: Project cannot be made Available any more times."
-                    )
-
                 try:
                     # add a fake archived status to mimick a re-release in order to have an udpated deadline
                     new_status_row = self.expire_project(
@@ -280,17 +275,7 @@ class ProjectStatus(flask_restful.Resource):
                 except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.SQLAlchemyError) as err:
                     flask.current_app.logger.exception(err)
                     db.session.rollback()
-                    raise DatabaseError(
-                        message=str(err),
-                        alt_message=(
-                            "Status was not updated"
-                            + (
-                                ": Database malfunction."
-                                if isinstance(err, sqlalchemy.exc.OperationalError)
-                                else ": Server Error."
-                            )
-                        ),
-                    ) from err
+                    raise err
 
                 return_message = f"{project.public_id} has been given a new deadline"
 

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -192,6 +192,7 @@ class ProjectStatus(flask_restful.Resource):
     @logging_bind_request
     @json_required
     @handle_validation_errors
+    @handle_db_error
     def patch(self):
         """Partially update a the project status"""
         # Get project ID, project and verify access

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -207,14 +207,14 @@ class ProjectStatus(flask_restful.Resource):
         if not isinstance(confirmed_operation, bool):
             raise DDSArgumentError(message="`confirmed` is a boolean value: True or False.")
         if not confirmed_operation:
-            warning_message = "Operation must be confirmed before proceding"
+            warning_message = "Operation must be confirmed before proceding."
             return {"warning": warning_message}
 
         # Cannot change project status if project is busy
         if project.busy:
             raise ProjectBusyError(
                 message=(
-                    f"The status for the project '{project_id}' is already in the process of being changed. "
+                    f"The deadline for the project '{project_id}' is already in the process of being changed. "
                     "Please try again later. \n\nIf you know the project is not busy, contact support."
                 )
             )
@@ -233,7 +233,7 @@ class ProjectStatus(flask_restful.Resource):
                 # deadline can only be extended from Available
                 if not project.current_status == "Available":
                     raise DDSArgumentError(
-                        "you can only extend the deadline for a project that has the status Available"
+                        "you can only extend the deadline for a project that has the status Available."
                     )
 
                 new_deadline_in = json_input.get("new_deadline_in")
@@ -245,7 +245,7 @@ class ProjectStatus(flask_restful.Resource):
                     )
                 if current_deadline > 10:
                     raise DDSArgumentError(
-                        message=f"There are still {current_deadline} days left, it is not possible to extend deadline yet"
+                        message=f"There are still {current_deadline} days left, it is not possible to extend deadline yet."
                     )
                 if new_deadline_in + current_deadline > 90:
                     raise DDSArgumentError(
@@ -254,7 +254,7 @@ class ProjectStatus(flask_restful.Resource):
 
                 if project.times_expired > 2:
                     raise DDSArgumentError(
-                        "The project has already been available for download 3 times. cannot extend the deadline again"
+                        "Project availability limit: Project cannot be made Available any more times."
                     )
 
                 try:

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -245,7 +245,6 @@ class ProjectStatus(flask_restful.Resource):
             )  # if not provided --> is None -> deadline is not updated
 
             # some variable definition
-            curr_date = dds_web.utils.current_time()
             send_email = False
             default_unit_days = project.responsible_unit.days_in_available
 
@@ -269,6 +268,7 @@ class ProjectStatus(flask_restful.Resource):
                     )
 
                 # the new deadline + days left shouldnt surpass 90 days
+                curr_date = dds_web.utils.current_time()
                 current_deadline = (project.current_deadline - curr_date).days
                 if new_deadline_in + current_deadline > 90:
                     raise DDSArgumentError(
@@ -276,13 +276,19 @@ class ProjectStatus(flask_restful.Resource):
                     )
                 try:
                     # add a fake expire status to mimick a re-release in order to have an udpated deadline
+                    curr_date = (
+                        dds_web.utils.current_time()
+                    )  # call current_time before each call so it is stored with different timestamps
                     new_status_row = self.expire_project(
                         project=project,
                         current_time=curr_date,
-                        deadline_in=project.responsible_unit.days_in_expired,
+                        deadline_in=1,  # some dummy deadline bc it will re-release now again
                     )
                     project.project_statuses.append(new_status_row)
 
+                    curr_date = (
+                        dds_web.utils.current_time()
+                    )  # call current_time before each call so it is stored with different timestamps
                     new_status_row = self.release_project(
                         project=project,
                         current_time=curr_date,

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -267,9 +267,14 @@ class ProjectStatus(flask_restful.Resource):
                     raise DDSArgumentError(
                         message=f"You requested the deadline to be extended with {new_deadline_in} days (from {current_deadline}), giving a new total deadline of {new_deadline_in + current_deadline} days. The new deadline needs to be less than (or equal to) 90 days."
                     )
-
+                # the dealine has changed at least two times, next time it expires
+                # wont change again -> error
+                if project.times_expired >= 2:
+                    raise DDSArgumentError(
+                        "Project availability limit: Project cannot be made Available any more times"
+                    )
                 try:
-                    # add a fake archived status to mimick a re-release in order to have an udpated deadline
+                    # add a fake expire status to mimick a re-release in order to have an udpated deadline
                     new_status_row = self.expire_project(
                         project=project,
                         current_time=curr_date,

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -265,7 +265,7 @@ class ProjectStatus(flask_restful.Resource):
                 # New deadline shouldnt surpass the default unit days
                 if new_deadline_in > default_unit_days:
                     raise DDSArgumentError(
-                        message=f"You requested the deadline to be extended {new_deadline_in}. The number of days has to be lower than the default deadline extension number of {default_unit_days} days"
+                        message=f"You requested the deadline to be extended {new_deadline_in} days. The number of days has to be lower than the default deadline extension number of {default_unit_days} days"
                     )
 
                 # the new deadline + days left shouldnt surpass 90 days

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -225,7 +225,7 @@ class ProjectStatus(flask_restful.Resource):
             raise ProjectBusyError(
                 message=(
                     f"The deadline for the project '{project_id}' is already in the process of being changed. "
-                    "Please try again later. \n\nIf you know the project is not busy, contact support."
+                    "Please try again later. \n\nIf you know that the project is not busy, contact support."
                 )
             )
 

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -221,6 +221,7 @@ class ProjectStatus(flask_restful.Resource):
 
         self.set_busy(project=project, busy=True)
 
+        # Extend deadline
         try:
             extend_deadline = json_input.get("extend_deadline", False)  # False by default
 

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -239,6 +239,11 @@ class ProjectStatus(flask_restful.Resource):
                         "You can only extend the deadline for a project that has the status 'Available'."
                     )
 
+                if type(new_deadline_in) is not int:
+                    raise DDSArgumentError(
+                        message="The deadline atribute passed should be of type Int (i.e a number)."
+                    )
+                
                 # it shouldnt surpass 90 days
                 current_deadline = (project.current_deadline - curr_date).days
                 if new_deadline_in + current_deadline > 90:
@@ -246,10 +251,6 @@ class ProjectStatus(flask_restful.Resource):
                         message=f"You requested the deadline to be extended with {new_deadline_in} days (from {current_deadline}), giving a new total deadline of {new_deadline_in + current_deadline} days. The new deadline needs to be less than (or equal to) 90 days."
                     )
 
-                if type(new_deadline_in) is not int:
-                    raise DDSArgumentError(
-                        message=" The deadline atribute passed should be of type Int (i.e a number)."
-                    )
                 try:
                     # add a fake archived status to mimick a re-release in order to have an udpated deadline
                     new_status_row = self.expire_project(

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -199,7 +199,7 @@ class ProjectStatus(flask_restful.Resource):
         project = dds_web.utils.collect_project(project_id=project_id)
         dds_web.utils.verify_project_access(project=project)
 
-        # get atributes
+        # Get json input from request
         json_input = flask.request.get_json(silent=True)  # Already checked by json_required
 
         # false by default - operation must be confirmed by the user

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -252,7 +252,7 @@ class ProjectStatus(flask_restful.Resource):
 
                 if type(new_deadline_in) is not int:
                     raise DDSArgumentError(
-                        message="The deadline atribute passed should be of type Int (i.e a number)."
+                        message="The deadline attribute passed should be of type Int (i.e a number)."
                     )
 
                 # New deadline shouldnt surpass the default unit days

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -292,10 +292,9 @@ class ProjectStatus(flask_restful.Resource):
                     db.session.rollback()
                     raise
 
-                return_message = f"{project.public_id} has been given a new deadline"
-
-                return_message += (
-                    f". An e-mail notification has{' not ' if not send_email else ' '}been sent."
+                return_message = (
+                    f"{project.public_id} has been given a new deadline. "
+                    f"An e-mail notification has{' not ' if not send_email else ' '}been sent."
                 )
             else:
                 # leave it for future new functionality of updating the status

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -233,7 +233,7 @@ class ProjectStatus(flask_restful.Resource):
         try:
             new_deadline_in = json_input.get(
                 "new_deadline_in", None
-            )  # if not provided is None -> deadlie is not updated
+            )  # if not provided --> is None -> deadline is not updated
 
             # some variable definition
             curr_date = dds_web.utils.current_time()

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -240,6 +240,7 @@ class ProjectStatus(flask_restful.Resource):
             # some variable definition
             curr_date = dds_web.utils.current_time()
             send_email = False
+            default_unit_days = project.responsible_unit.days_in_expired
 
             # Update the deadline functionality
             if new_deadline_in:
@@ -254,7 +255,13 @@ class ProjectStatus(flask_restful.Resource):
                         message="The deadline atribute passed should be of type Int (i.e a number)."
                     )
 
-                # it shouldnt surpass 90 days
+                # New deadline shouldnt surpass the default unit days
+                if new_deadline_in > default_unit_days:
+                    raise DDSArgumentError(
+                        message=f"You requested the deadline to be extended {new_deadline_in}. The number of days has to be lower than the default deadline extension number of {default_unit_days} days"
+                    )
+
+                # the new deadline + days left shouldnt surpass 90 days
                 current_deadline = (project.current_deadline - curr_date).days
                 if new_deadline_in + current_deadline > 90:
                     raise DDSArgumentError(

--- a/doc/status_codes_api.md
+++ b/doc/status_codes_api.md
@@ -237,6 +237,11 @@
   - `archive_project`
     - Database or S3 issues
 
+#### `patch`
+
+- [Authentication errors](#authentication)
+
+
 ### GetPublic
 
 - [Authentication errors](#authentication)

--- a/doc/status_codes_api.md
+++ b/doc/status_codes_api.md
@@ -240,7 +240,27 @@
 #### `patch`
 
 - [Authentication errors](#authentication)
-
+- `400 Bad Request`
+  - Decorators
+    - Json required but not provided
+    - Validation error
+  - Schemas
+    - Project does not exist
+  - Project is busy
+  - `extend_deadline`
+    - Invalid deadline
+    - No deadline provided
+    - Project is not in Available state
+    - Max number of times available reached
+- `403 Forbidden`
+  - Schemas
+    - User does not have access to project
+- `500 Internal Server Error`
+  - Database errors
+  - `delete_project`
+    - Database or S3 issues
+  - `archive_project`
+    - Database or S3 issues
 
 ### GetPublic
 

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1116,7 +1116,7 @@ def test_extend_deadline(module_client, boto3_session):
         tests.DDSEndpoint.PROJECT_STATUS,
         headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
         query_string={"project": project_id},
-        json={"extend_deadline": True, "new_deadline_in": 20},
+        json={"extend_deadline": True, "new_deadline_in": 20, "confirmed": True},
     )
     assert response.status_code == http.HTTPStatus.OK
     assert project.times_expired == 1

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1371,6 +1371,7 @@ def test_extend_deadline_maxium_number_available_exceded(module_client, boto3_se
             assert project.times_expired == i
             assert project.current_deadline == deadline + datetime.timedelta(days=new_deadline_in)
             deadline = project.current_deadline  # update current deadline
+            assert project.current_status == "Available"
             assert (
                 f"The project '{project_id}' has been given a new deadline"
                 in response.json["message"]
@@ -1408,6 +1409,7 @@ def test_extend_deadline_ok(module_client, boto3_session):
     assert project.current_deadline == deadline + datetime.timedelta(
         days=extend_deadline_data.get("new_deadline_in")
     )
+    assert project.current_status == "Available"
 
     assert f"The project '{project_id}' has been given a new deadline" in response.json["message"]
     assert "An e-mail notification has not been sent." in response.json["message"]

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1267,12 +1267,12 @@ def test_extend_deadline_too_much_days(module_client, boto3_session):
     time.sleep(1)  # tests are too fast
 
     # try to extend deadline by a lot of days
-    extend_deadline_data = {**extend_deadline_data, "new_deadline_in": 90}
+    extend_deadline_data_big_deadline = {**extend_deadline_data, "new_deadline_in": 90}
     response = module_client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
         headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
         query_string={"project": project_id},
-        json=extend_deadline_data,
+        json=extend_deadline_data_big_deadline,
     )
     assert response.status_code == http.HTTPStatus.BAD_REQUEST
     assert (
@@ -1291,16 +1291,17 @@ def test_extend_deadline_bad_new_deadline(module_client, boto3_session):
     time.sleep(1)  # tests are too fast
 
     # try to extend deadline with a bad new deadline
-    extend_deadline_data = {**extend_deadline_data, "new_deadline_in": "20"}
+    extend_deadline_data_bad_deadline = {**extend_deadline_data, "new_deadline_in": "20"}
     response = module_client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
         headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
         query_string={"project": project_id},
-        json=extend_deadline_data,
+        json=extend_deadline_data_bad_deadline,
     )
     assert response.status_code == http.HTTPStatus.BAD_REQUEST
     assert (
-        "The new deadline needs to be less than (or equal to) 90 days." in response.json["message"]
+        "The deadline atribute passed should be of type Int (i.e a number)."
+        in response.json["message"]
     )
 
 

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1376,7 +1376,7 @@ def test_extend_deadline_maxium_number_available_exceded(module_client, boto3_se
         else:
             assert response.status_code == http.HTTPStatus.BAD_REQUEST
             assert (
-                "Project availability limit: Project cannot be made Available any more times"
+                "Project availability limit: The maximun number of changes in data availability has been reached."
                 in response.json["message"]
             )
 

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -4,6 +4,7 @@
 import http
 from sqlite3 import OperationalError
 import pytest
+from _pytest.logging import LogCaptureFixture
 import datetime
 import time
 import unittest.mock
@@ -1364,7 +1365,9 @@ def test_extend_deadline_ok(module_client, boto3_session):
     assert "An e-mail notification has not been sent." in response.json["message"]
 
 
-def test_extend_deadline_mock_database_error(module_client, boto3_session):
+def test_extend_deadline_mock_database_error(
+    module_client, boto3_session, capfd: LogCaptureFixture
+):
     """Mock error when performing the request"""
 
     project_id, project = create_and_release_project(
@@ -1384,6 +1387,9 @@ def test_extend_deadline_mock_database_error(module_client, boto3_session):
         )
         assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
         assert "Saving database changes failed." in response.json["message"]
+
+        _, err = capfd.readouterr()
+        assert "500 Internal Server Error: Saving database changes failed." in err
 
 
 def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3_session):

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1227,7 +1227,7 @@ def test_extend_deadline_project_not_available(module_client, boto3_session):
     assert response.status_code == http.HTTPStatus.BAD_REQUEST
 
     assert (
-        "you can only extend the deadline for a project that has the status Available."
+        "You can only extend the deadline for a project that has the status 'Available'."
         in response.json["message"]
     )
 
@@ -1250,33 +1250,6 @@ def test_extend_deadline_no_deadline(module_client, boto3_session):
     )
     assert response.status_code == http.HTTPStatus.BAD_REQUEST
     assert "No new deadline provived, cannot perform operation." in response.json["message"]
-
-
-def test_extend_deadline_not_enough_time_left(module_client, boto3_session):
-    """If there are still too much days left, extend deadline should not be yet possible"""
-
-    # create and release a new project with a long time left as available
-    current_deadline = 90
-    release_data_long_deadline = {"new_status": "Available", "deadline": current_deadline}
-    project_id, project = create_and_release_project(
-        client=module_client, proj_data=proj_data, release_data=release_data_long_deadline
-    )
-    assert project.times_expired == 0
-    time.sleep(1)  # tests are too fast
-
-    # try to extend upon such deadline
-    response = module_client.patch(
-        tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
-        query_string={"project": project_id},
-        json={"extend_deadline": True, "new_deadline_in": 20, "confirmed": True},
-    )
-    assert response.status_code == http.HTTPStatus.BAD_REQUEST
-    assert (
-        f"There are still {current_deadline} days left, it is not possible to extend deadline yet."
-        in response.json["message"]
-    )
-
 
 def test_extend_deadline_too_much_days(module_client, boto3_session):
     """If the new deadline together with the time left already is more than 90 days it should not work"""

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1167,6 +1167,7 @@ def test_extend_deadline_no_confirmed(module_client, boto3_session):
     assert project.times_expired == 0
 
     assert "Operation must be confirmed before proceding." in response.json["warning"]
+    assert all(item in response.json for item in ["project_info", "project_status", "warning", "default_unit_days"])
 
 
 def test_extend_deadline_when_busy(module_client, boto3_session):

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1198,7 +1198,7 @@ def test_extend_deadline_when_busy(module_client, boto3_session):
         in response.json["message"]
     )
     assert (
-        "Please try again later. \n\nIf you know the project is not busy, contact support."
+        "Please try again later. \n\nIf you know that the project is not busy, contact support."
         in response.json["message"]
     )
 
@@ -1302,7 +1302,7 @@ def test_extend_deadline_bad_new_deadline(module_client, boto3_session):
     )
     assert response.status_code == http.HTTPStatus.BAD_REQUEST
     assert (
-        "The deadline atribute passed should be of type Int (i.e a number)."
+        "The deadline attribute passed should be of type Int (i.e a number)."
         in response.json["message"]
     )
 

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -46,7 +46,9 @@ fields_set_to_null = [
     # "date_updated",
 ]
 
-release_project_small_deadline = {"new_status": "Available", "deadline": 5}
+release_project = {"new_status": "Available"}
+release_project_small_deadline = {**release_project, "deadline": 5}
+release_project_big_deadline = {**release_project, "deadline": 80}
 
 extend_deadline_data_no_confirmed = {
     "new_deadline_in": 20,
@@ -1127,7 +1129,7 @@ def test_extend_deadline_bad_confirmed(module_client, boto3_session):
 
     # create project and release it
     project_id, project = create_and_release_project(
-        client=module_client, proj_data=proj_data, release_data={"new_status": "Available"}
+        client=module_client, proj_data=proj_data, release_data=release_project
     )
     assert project.times_expired == 0
     time.sleep(1)  # tests are too fast
@@ -1148,7 +1150,7 @@ def test_extend_deadline_no_confirmed(module_client, boto3_session):
 
     # create project and release it
     project_id, project = create_and_release_project(
-        client=module_client, proj_data=proj_data, release_data={"new_status": "Available"}
+        client=module_client, proj_data=proj_data, release_data=release_project
     )
     assert project.times_expired == 0
     time.sleep(1)  # tests are too fast
@@ -1172,7 +1174,7 @@ def test_extend_deadline_when_busy(module_client, boto3_session):
 
     # create project and release it
     project_id, project = create_and_release_project(
-        client=module_client, proj_data=proj_data, release_data={"new_status": "Available"}
+        client=module_client, proj_data=proj_data, release_data=release_project
     )
     assert project.times_expired == 0
     time.sleep(1)  # tests are too fast
@@ -1206,7 +1208,7 @@ def test_extend_deadline_no_deadline(module_client, boto3_session):
 
     # create project and release it
     project_id, project = create_and_release_project(
-        client=module_client, proj_data=proj_data, release_data={"new_status": "Available"}
+        client=module_client, proj_data=proj_data, release_data=release_project
     )
     assert project.times_expired == 0
     time.sleep(1)  # tests are too fast
@@ -1259,15 +1261,15 @@ def test_extend_deadline_project_not_available(module_client, boto3_session):
 def test_extend_deadline_too_much_days(module_client, boto3_session):
     """If the new deadline together with the time left already is more than 90 days it should not work"""
 
-    # create project and release it
+    # create project and release it with big dealdine
     project_id, project = create_and_release_project(
-        client=module_client, proj_data=proj_data, release_data=release_project_small_deadline
+        client=module_client, proj_data=proj_data, release_data=release_project_big_deadline
     )
     assert project.times_expired == 0
     time.sleep(1)  # tests are too fast
 
-    # try to extend deadline by a lot of days
-    extend_deadline_data_big_deadline = {**extend_deadline_data, "new_deadline_in": 90}
+    # try to extend deadline -> 80 + 11 > 90
+    extend_deadline_data_big_deadline = {**extend_deadline_data, "new_deadline_in": 11}
     response = module_client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
         headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
@@ -1285,7 +1287,7 @@ def test_extend_deadline_bad_new_deadline(module_client, boto3_session):
 
     # create project and release it
     project_id, project = create_and_release_project(
-        client=module_client, proj_data=proj_data, release_data=release_project_small_deadline
+        client=module_client, proj_data=proj_data, release_data=release_project
     )
     assert project.times_expired == 0
     time.sleep(1)  # tests are too fast
@@ -1301,6 +1303,36 @@ def test_extend_deadline_bad_new_deadline(module_client, boto3_session):
     assert response.status_code == http.HTTPStatus.BAD_REQUEST
     assert (
         "The deadline atribute passed should be of type Int (i.e a number)."
+        in response.json["message"]
+    )
+
+
+def test_extend_deadline_more_than_default(module_client, boto3_session):
+    """If the new deadline provided is more than the default unit days to release a project it should fail"""
+
+    # create project and release it
+    project_id, project = create_and_release_project(
+        client=module_client, proj_data=proj_data, release_data=release_project_small_deadline
+    )
+    assert project.times_expired == 0
+    time.sleep(1)  # tests are too fast
+
+    default_unit_days = project.responsible_unit.days_in_expired
+
+    # try to extend deadline with a bigger deadline that it is suppose to have
+    extend_deadline_data_bad_deadline = {
+        **extend_deadline_data,
+        "new_deadline_in": default_unit_days + 1,
+    }
+    response = module_client.patch(
+        tests.DDSEndpoint.PROJECT_STATUS,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        query_string={"project": project_id},
+        json=extend_deadline_data_bad_deadline,
+    )
+    assert response.status_code == http.HTTPStatus.BAD_REQUEST
+    assert (
+        "The number of days has to be lower than the default deadline extension number"
         in response.json["message"]
     )
 

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1089,16 +1089,16 @@ def test_projectstatus_post_invalid_deadline_expire(module_client, boto3_session
     assert "The deadline needs to be less than (or equal to) 30 days." in response.json["message"]
 
 
-def test_extend_deadline_bad_confirmed(module_client, boto3_session):
+def test_extend_deadline_bad_confirmed(client, boto3_session):
     """Try to extend a deadline and send a not boolean for confirmation"""
 
     project, _ = get_existing_projects()
     project_id = project.public_id
 
     # Release project
-    response = module_client.post(
+    response = client.post(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json={"new_status": "Available"},
     )
@@ -1106,10 +1106,12 @@ def test_extend_deadline_bad_confirmed(module_client, boto3_session):
     # hasnt been expired or extended deadline yet
     assert project.times_expired == 0
 
+    time.sleep(1)  # tests are too fast
+
     # extend deadline
-    response = module_client.patch(
+    response = client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json={**extend_deadline_data, "confirmed": "true"},
     )
@@ -1117,16 +1119,16 @@ def test_extend_deadline_bad_confirmed(module_client, boto3_session):
     assert "`confirmed` is a boolean value: True or False." in response.json["message"]
 
 
-def test_extend_deadline_no_confirmed(module_client, boto3_session):
+def test_extend_deadline_no_confirmed(client, boto3_session):
     """Try to extend a deadline before confirmation should sent a warning and no operation perfrom"""
 
     project, _ = get_existing_projects()
     project_id = project.public_id
 
     # Release project
-    response = module_client.post(
+    response = client.post(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json={"new_status": "Available"},
     )
@@ -1134,10 +1136,12 @@ def test_extend_deadline_no_confirmed(module_client, boto3_session):
     # hasnt been expired or extended deadline yet
     assert project.times_expired == 0
 
+    time.sleep(1)  # tests are too fast
+
     # extend deadline
-    response = module_client.patch(
+    response = client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json=extend_deadline_data_no_confirmed,
     )
@@ -1148,16 +1152,16 @@ def test_extend_deadline_no_confirmed(module_client, boto3_session):
     assert "Operation must be confirmed before proceding." in response.json["warning"]
 
 
-def test_extend_deadline_when_busy(module_client, boto3_session):
+def test_extend_deadline_when_busy(client, boto3_session):
     """Request should not be possible when project is busy."""
 
     project, _ = get_existing_projects()
     project_id = project.public_id
 
     # Release project
-    response = module_client.post(
+    response = client.post(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json={"new_status": "Available"},
     )
@@ -1173,9 +1177,9 @@ def test_extend_deadline_when_busy(module_client, boto3_session):
     time.sleep(1)  # tests are too fast
 
     # attempt to extend deadline
-    response = module_client.patch(
+    response = client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json=extend_deadline_data,
     )
@@ -1191,16 +1195,16 @@ def test_extend_deadline_when_busy(module_client, boto3_session):
     )
 
 
-def test_extend_deadline_project_not_available(module_client, boto3_session):
+def test_extend_deadline_project_not_available(client, boto3_session):
     """Is not possible to extend deadline to project in other status than available."""
 
     project, _ = get_existing_projects()
     project_id = project.public_id
 
     # attempt to extend deadline - project is in progress
-    response = module_client.patch(
+    response = client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json=extend_deadline_data,
     )
@@ -1212,16 +1216,16 @@ def test_extend_deadline_project_not_available(module_client, boto3_session):
     )
 
 
-def test_extend_deadline_no_deadline(module_client, boto3_session):
+def test_extend_deadline_no_deadline(client, boto3_session):
     """If no deadline has been provided it should fail"""
 
     project, _ = get_existing_projects()
     project_id = project.public_id
 
     # Release project
-    response = module_client.post(
+    response = client.post(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json={"new_status": "Available"},
     )
@@ -1229,10 +1233,12 @@ def test_extend_deadline_no_deadline(module_client, boto3_session):
     # hasnt been expired or extended deadline yet
     assert project.times_expired == 0
 
+    time.sleep(1)  # tests are too fast
+
     # try to extend deadline
-    response = module_client.patch(
+    response = client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json={"extend_deadline": True, "confirmed": True},
     )
@@ -1240,7 +1246,7 @@ def test_extend_deadline_no_deadline(module_client, boto3_session):
     assert "No new deadline provived, cannot perform operation." in response.json["message"]
 
 
-def test_extend_deadline_not_enough_time_left(module_client, boto3_session):
+def test_extend_deadline_not_enough_time_left(client, boto3_session):
     """If there are more than 10 days left, extend deadline should not be possible"""
 
     project, _ = get_existing_projects()
@@ -1248,9 +1254,9 @@ def test_extend_deadline_not_enough_time_left(module_client, boto3_session):
 
     # Release project with a big deadline
     current_deadline = 30
-    response = module_client.post(
+    response = client.post(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json={"new_status": "Available", "deadline": current_deadline},
     )
@@ -1258,10 +1264,12 @@ def test_extend_deadline_not_enough_time_left(module_client, boto3_session):
     # hasnt been expired or extended deadline yet
     assert project.times_expired == 0
 
+    time.sleep(1)  # tests are too fast
+
     # try to extend upon such deadline
-    response = module_client.patch(
+    response = client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json={"extend_deadline": True, "new_deadline_in": 20, "confirmed": True},
     )
@@ -1272,16 +1280,16 @@ def test_extend_deadline_not_enough_time_left(module_client, boto3_session):
     )
 
 
-def test_extend_deadline_too_much_days(module_client, boto3_session):
+def test_extend_deadline_too_much_days(client, boto3_session):
     """If the new deadline together with the time left already is more than 90 days it should not work"""
 
     project, _ = get_existing_projects()
     project_id = project.public_id
 
     # Release project with a small deadline
-    response = module_client.post(
+    response = client.post(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json=release_project_small_deadline,
     )
@@ -1289,8 +1297,10 @@ def test_extend_deadline_too_much_days(module_client, boto3_session):
     # hasnt been expired or extended deadline yet
     assert project.times_expired == 0
 
+    time.sleep(1)  # tests are too fast
+
     # try to extend deadline a lot of days
-    response = module_client.patch(
+    response = client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
         headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
         query_string={"project": project_id},
@@ -1302,16 +1312,16 @@ def test_extend_deadline_too_much_days(module_client, boto3_session):
     )
 
 
-def test_extend_deadline_maxium_number_available_exceded(module_client, boto3_session):
+def test_extend_deadline_maxium_number_available_exceded(client, boto3_session):
     """If the deadline has been extended more than 2 times it should not work"""
 
     project, _ = get_existing_projects()
     project_id = project.public_id
 
     # Release project with a small deadline
-    response = module_client.post(
+    response = client.post(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json=release_project_small_deadline,
     )
@@ -1326,9 +1336,9 @@ def test_extend_deadline_maxium_number_available_exceded(module_client, boto3_se
         time.sleep(1)  # tests are too fast
 
         # extend deadline with a small new deadline so we can do it several times
-        response = module_client.patch(
+        response = client.patch(
             tests.DDSEndpoint.PROJECT_STATUS,
-            headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+            headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
             query_string={"project": project_id},
             json={**extend_deadline_data, "new_deadline_in": new_deadline_in},
         )
@@ -1347,16 +1357,16 @@ def test_extend_deadline_maxium_number_available_exceded(module_client, boto3_se
             )
 
 
-def test_extend_deadline_ok(module_client, boto3_session):
+def test_extend_deadline_ok(client, boto3_session):
     """Extend a project deadline of a project already release"""
 
     project, _ = get_existing_projects()
     project_id = project.public_id
 
     # Release project with a small deadline
-    response = module_client.post(
+    response = client.post(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json=release_project_small_deadline,
     )
@@ -1368,9 +1378,9 @@ def test_extend_deadline_ok(module_client, boto3_session):
     time.sleep(1)  # tests are too fast
 
     # extend deadline
-    response = module_client.patch(
+    response = client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json=extend_deadline_data,
     )
@@ -1384,16 +1394,16 @@ def test_extend_deadline_ok(module_client, boto3_session):
     assert "An e-mail notification has not been sent." in response.json["message"]
 
 
-def test_extend_deadline_mock_database_error(module_client, boto3_session):
+def test_extend_deadline_mock_database_error(client, boto3_session):
     """Mock error when updating the database"""
 
     project, _ = get_existing_projects()
     project_id = project.public_id
 
     # Release project with a small deadline
-    response = module_client.post(
+    response = client.post(
         tests.DDSEndpoint.PROJECT_STATUS,
-        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client),
         query_string={"project": project_id},
         json=release_project_small_deadline,
     )
@@ -1403,10 +1413,10 @@ def test_extend_deadline_mock_database_error(module_client, boto3_session):
 
     time.sleep(1)  # tests are too fast
 
-    token = tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client)
+    token = tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(client)
     with unittest.mock.patch("dds_web.db.session.commit", mock_sqlalchemyerror):
         # extend deadline
-        response = module_client.patch(
+        response = client.patch(
             tests.DDSEndpoint.PROJECT_STATUS,
             headers=token,
             query_string={"project": project_id},

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1092,14 +1092,7 @@ def test_projectstatus_post_invalid_deadline_expire(module_client, boto3_session
 def test_extend_deadline_bad_confirmed(module_client, boto3_session):
     """Try to extend a deadline and send a not boolean for confirmation"""
 
-    username = "researchuser"
-    # Get user
-    user = models.User.query.filter_by(username=username).one_or_none()
-    assert user
-
-    # Get project
-    project = user.projects[0]
-    assert project
+    project, _ = get_existing_projects()
     project_id = project.public_id
 
     # Release project
@@ -1113,13 +1106,12 @@ def test_extend_deadline_bad_confirmed(module_client, boto3_session):
     # hasnt been expired or extended deadline yet
     assert project.times_expired == 0
 
-    json_data = {**extend_deadline_data, "confirmed": "true"}
     # extend deadline
     response = module_client.patch(
         tests.DDSEndpoint.PROJECT_STATUS,
         headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
         query_string={"project": project_id},
-        json=json_data,
+        json={**extend_deadline_data, "confirmed": "true"},
     )
     assert response.status_code == http.HTTPStatus.BAD_REQUEST
     assert "`confirmed` is a boolean value: True or False." in response.json["message"]

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1376,7 +1376,7 @@ def test_extend_deadline_maxium_number_available_exceded(module_client, boto3_se
         else:
             assert response.status_code == http.HTTPStatus.BAD_REQUEST
             assert (
-                "Project availability limit: The maximun number of changes in data availability has been reached."
+                "Project availability limit: The maximum number of changes in data availability has been reached."
                 in response.json["message"]
             )
 

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1321,7 +1321,7 @@ def test_extend_deadline_more_than_default(module_client, boto3_session):
     assert project.times_expired == 0
     time.sleep(1)  # tests are too fast
 
-    default_unit_days = project.responsible_unit.days_in_expired
+    default_unit_days = project.responsible_unit.days_in_available
 
     # try to extend deadline with a bigger deadline that it is suppose to have
     extend_deadline_data_bad_deadline = {
@@ -1371,7 +1371,10 @@ def test_extend_deadline_maxium_number_available_exceded(module_client, boto3_se
             assert project.times_expired == i
             assert project.current_deadline == deadline + datetime.timedelta(days=new_deadline_in)
             deadline = project.current_deadline  # update current deadline
-            assert f"{project_id} has been given a new deadline" in response.json["message"]
+            assert (
+                f"The project '{project_id}' has been given a new deadline"
+                in response.json["message"]
+            )
             assert "An e-mail notification has not been sent." in response.json["message"]
         else:
             assert response.status_code == http.HTTPStatus.BAD_REQUEST
@@ -1406,7 +1409,7 @@ def test_extend_deadline_ok(module_client, boto3_session):
         days=extend_deadline_data.get("new_deadline_in")
     )
 
-    assert f"{project_id} has been given a new deadline" in response.json["message"]
+    assert f"The project '{project_id}' has been given a new deadline" in response.json["message"]
     assert "An e-mail notification has not been sent." in response.json["message"]
 
 

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1251,6 +1251,7 @@ def test_extend_deadline_no_deadline(module_client, boto3_session):
     assert response.status_code == http.HTTPStatus.BAD_REQUEST
     assert "No new deadline provived, cannot perform operation." in response.json["message"]
 
+
 def test_extend_deadline_too_much_days(module_client, boto3_session):
     """If the new deadline together with the time left already is more than 90 days it should not work"""
 

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1167,7 +1167,10 @@ def test_extend_deadline_no_confirmed(module_client, boto3_session):
     assert project.times_expired == 0
 
     assert "Operation must be confirmed before proceding." in response.json["warning"]
-    assert all(item in response.json for item in ["project_info", "project_status", "warning", "default_unit_days"])
+    assert all(
+        item in response.json
+        for item in ["project_info", "project_status", "warning", "default_unit_days"]
+    )
 
 
 def test_extend_deadline_when_busy(module_client, boto3_session):


### PR DESCRIPTION
## Read this before submitting the PR

1. Always create a Draft PR first
2. Go through sections 1-5 below, fill them in and check all the boxes
3. Make sure that the branch is updated; if there's an "Update branch" button at the bottom of the PR, rebase or update branch.
4. When all boxes are checked, information is filled in, and the branch is updated: mark as Ready For Review and tag reviewers (top right)
5. Once there is a submitted review, implement the suggestions (if reasonable, otherwise discuss) and request an new review.

If there is a field which you are unsure about, enter the edit mode of this description or go to the [PR template](../.github/pull_request_template.md); There are invisible comments providing descriptions which may be of help.

## 1. Description / Summary

Implemented the functionality in the API of extend the deadline for a project with a new endpoint:

The new endpoint is PATCH /proj/status 

Currently, it only supports the functionality of extending the deadline for which the following body is necessary:

```
{
"new_deadline_in": int
}

```
If, _new_deadline_in_  has not been provided then, nothing is executed. If it is provided, it needs to be an integer that defines the extension in days for the new deadline. These days while be added on top of the current day's left.

The workflow process that should be handled when **project status extend deadline** is called is as follows:

1.  CLI: call ProjectStatus.patch
2. API: ProjectStatus.patch returns project status and deadline (days left)
3. CLI: Print _project status, deadline_, and chosen _new deadline_. Ask for confirmation.
4. CLI: call ProjectStatus.patch with confirmed flag
5. API: ProjectStatus.patch verifies correct status, and ok deadline, and extends the deadline.
    
    
    
    


## 2. Jira task / GitHub issue

[_Link to the github issue or add the Jira task ID here._](https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?isInsightsOpen=true&selectedIssue=DDS-1691)

## 3. Type of change

What _type of change(s)_ does the PR contain?

**Check the relevant boxes below. For an explanation of the different sections, enter edit mode of this PR description template.**

- [x] New feature
  - [ ] Breaking: _Why / How? Add info here._ <!-- Should be checked if the changes in this PR will cause existing functionality to not work as expected. E.g. with the master branch of the `dds_cli` -->
  - [x] Non-breaking <!-- Should be checked if the changes will not cause existing functionality to fail. "Non-breaking" is just an addition of a new feature. -->
- [ ] Database change: _Remember the to include a new migration version, **or** explain here why it's not needed._ <!-- Should be checked when you've changed something in `models.py`. For a guide on how to add the a new migration version, look at the "Database changes" section in the README.md. -->
- [ ] Bug fix <!-- Should be checked when a bug is fixed in existing functionality. If the bug fix also is a breaking change (see above), add info about that beside this check box. -->
- [ ] Security Alert fix <!-- Should be checked if the PR attempts to solve a security vulnerability, e.g. reported by the "Security" tab in the repo. -->
- [ ] Documentation <!-- Should be checked if the PR adds or updates documentation such as e.g. Technical Overview or a architecture decision (dds_web/doc/architecture/decisions.) -->
- [ ] Workflow <!-- Should be checked if the PR includes a change in e.g. the github actions files (dds_web/.github/*) or another type of workflow change. Anything that alters our or the codes workflow. -->
- [ ] Tests **only** <!-- Should only be checked if the PR only contains tests, none of the other types of changes listed above. -->

## 4. Additional information

- [x] [Sprintlog](../SPRINTLOG.md) <!-- Add a row at the bottom of the SPRINTLOG.md file (not needed if PR contains only tests). Follow the format of previous rows. If the PR is the first in a new sprint, add a new sprint header row (follow the format of previous sprints). -->
- [ ] Blocking PRs <!-- Should be checked if there are blocking PRs or other tasks that need to be merged prior to this. Add link to PR or Jira card if this is the case. -->
  - [ ] Merged <!-- Should be checked if the "Blocking PRs" box was checked AND all blocking PRs have been merged / fixed. -->
- [ ] PR to `master` branch: \_If checked, read [the release instructions](../doc/procedures/new_release.md) <!-- Check this if the PR is made to the `master` branch. Only the `dev` branch should be doing this. -->
  - [ ] I have followed steps 1-8. <!-- Should be checked if the "PR to `master` branch" box is checked AND the specified steps in the release instructions have been followed. -->

## 5. Actions / Scans

_Check the boxes when the specified checks have passed._

**For information on what the different checks do and how to fix it if they're failing, enter edit mode of this description or go to the [PR template](../.github/pull_request_template.md).**

- [x] **Black**
<!--
  What: Python code formatter.
  How to fix: Run `black .` locally to execute formatting.
-->
- [x] **Prettier**
<!--
  What: General code formatter. Our use case: MD and yaml mainly.
  How to fix: Run npx prettier --write . locally to execute formatting.
-->
- [x] **Yamllint**
<!--
  What: Linting of yaml files.
  How to fix: Manually fix any errors locally.
-->
- [x] **Tests**
<!--
  What: Pytest to verify that functionality works as expected.
  How to fix: Manually fix any errors locally. Follow the instructions in the "Run tests" section of the README.md to run the tests locally.
  Additional info: The PR should ALWAYS include new tests or fixed tests when there are code changes. When pytest action has finished, it will post a codecov report; Look at this report and verify the files you have changed are listed. "90% <100.00%> (+0.8%)" means "Tests cover 90% of the changed file, <100 % of this PR's code changes are tested>, and (the code changes and added tests increased the overall test coverage with 0.8%)
-->
- [x] **CodeQL**
<!--
  What: Scan for security vulnerabilities, bugs, errors.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [x] **Trivy**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [x] **Snyk**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
