### PR TITLE
Fix bucket successfully deleted from S3 but DB update fails

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -393,4 +393,3 @@ _Nothing merged in CLI during this sprint_
 - Fix raising error when archiving project, bucket deleted but DB error ([#1524](https://github.com/ScilifelabDataCentre/dds_web/pull/1524))
 - Increase the identified less covered files([#1521](https://github.com/ScilifelabDataCentre/dds_web/pull/1521))
 - Parse boolean inputs correctly ([#1528](https://github.com/ScilifelabDataCentre/dds_web/pull/1528))
-

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -382,3 +382,4 @@ _Nothing merged in CLI during this sprint_
 # 2024-04-8 - 2024-04-19
 
 - New version: 2.6.4 ([#1526](https://github.com/ScilifelabDataCentre/dds_web/pull/1526))
+- Fix raising error when archiving project, bucket deleted but DB error ([#1524](https://github.com/ScilifelabDataCentre/dds_web/pull/1524))

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -383,7 +383,6 @@ _Nothing merged in CLI during this sprint_
 
 - New version: 2.6.4 ([#1526](https://github.com/ScilifelabDataCentre/dds_web/pull/1526))
 
-
 # 2024-05-6 - 2024-05-17
 
 - Fix the User endpoints according to OpenAPI standar ([#1524](https://github.com/ScilifelabDataCentre/dds_web/pull/1524))
@@ -392,4 +391,3 @@ _Nothing merged in CLI during this sprint_
 
 - Update Werkzeug and related libraries to solve CVE([#1530](https://github.com/ScilifelabDataCentre/dds_web/pull/1530))
 - Fix raising error when archiving project, bucket deleted but DB error ([#1524](https://github.com/ScilifelabDataCentre/dds_web/pull/1524))
-

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -767,25 +767,22 @@ class RemoveContents(flask_restful.Resource):
             sqlalchemy.exc.OperationalError,
             AttributeError,
         ) as sqlerr:
+            error_msg = (
+                "Project bucket contents were deleted, but they were not deleted from the "
+                "database. Please contact SciLifeLab Data Centre."
+                + (
+                    "Database malfunction."
+                    if isinstance(sqlerr, sqlalchemy.exc.OperationalError)
+                    else "."
+                )
+            )
             if flask.request:
                 raise DeletionError(
                     project=project.public_id,
                     message=str(sqlerr),
-                    alt_message=(
-                        "Project bucket contents were deleted, but they were not deleted from the "
-                        "database. Please contact SciLifeLab Data Centre."
-                        + (
-                            "Database malfunction."
-                            if isinstance(sqlerr, sqlalchemy.exc.OperationalError)
-                            else "."
-                        )
-                    ),
+                    alt_message=error_msg,
                 ) from sqlerr
             else:
-                error_msg = (
-                    "Project bucket contents were deleted, but they were not deleted from the "
-                    "database. Please contact SciLifeLab Data Centre."
-                )
                 flask.current_app.logger.exception(error_msg)
 
 

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -782,7 +782,11 @@ class RemoveContents(flask_restful.Resource):
                     ),
                 ) from sqlerr
             else:
-                raise
+                error_msg = (
+                    "Project bucket contents were deleted, but they were not deleted from the "
+                    "database. Please contact SciLifeLab Data Centre."
+                )
+                flask.current_app.logger.exception(error_msg)
 
 
 class CreateProject(flask_restful.Resource):

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -767,19 +767,23 @@ class RemoveContents(flask_restful.Resource):
             sqlalchemy.exc.OperationalError,
             AttributeError,
         ) as sqlerr:
-            raise DeletionError(
-                project=project.public_id,
-                message=str(sqlerr),
-                alt_message=(
-                    "Project bucket contents were deleted, but they were not deleted from the "
-                    "database. Please contact SciLifeLab Data Centre."
-                    + (
-                        "Database malfunction."
-                        if isinstance(err, sqlalchemy.exc.OperationalError)
-                        else "."
-                    )
-                ),
-            ) from sqlerr
+            import flask
+            if flask.has_request_context():
+                raise DeletionError(
+                    project=project.public_id,
+                    message=str(sqlerr),
+                    alt_message=(
+                        "Project bucket contents were deleted, but they were not deleted from the "
+                        "database. Please contact SciLifeLab Data Centre."
+                        + (
+                            "Database malfunction."
+                            if isinstance(sqlerr, sqlalchemy.exc.OperationalError)
+                            else "."
+                        )
+                    ),
+                ) from sqlerr
+            else:
+                raise
 
 
 class CreateProject(flask_restful.Resource):

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -767,9 +767,7 @@ class RemoveContents(flask_restful.Resource):
             sqlalchemy.exc.OperationalError,
             AttributeError,
         ) as sqlerr:
-            import flask
-
-            if flask.has_request_context():
+            if flask.request:
                 raise DeletionError(
                     project=project.public_id,
                     message=str(sqlerr),

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -768,6 +768,7 @@ class RemoveContents(flask_restful.Resource):
             AttributeError,
         ) as sqlerr:
             import flask
+
             if flask.has_request_context():
                 raise DeletionError(
                     project=project.public_id,

--- a/dds_web/commands.py
+++ b/dds_web/commands.py
@@ -691,7 +691,7 @@ def set_expired_to_archived():
                         )
                         flask.current_app.logger.debug(delete_message.strip())
                     except RuntimeError as err:
-                        # Because of how the application is set up, the only way to catch an error
+                        # Because of how the application is set up, the only way to catch this errors
                         # is to catch the RuntimeError, which is generated after a custom error (errors.py) fails
                         # to be initialized due to not being called in an API request
                         traceback = tb.format_exc()
@@ -703,8 +703,10 @@ def set_expired_to_archived():
                                 )
                                 break  # exit the traceback loop
                             if "DeletionError":
-                                message = "DeletionError: Project bucket contents were deleted, but they were not deleted from the "
-                                "database. Please contact SciLifeLab Data Centre."
+                                message = (
+                                    "DeletionError: Project bucket contents were deleted, but they were not deleted from the "
+                                    "database. Please contact SciLifeLab Data Centre."
+                                )
                                 break  # exit the traceback loop
                         flask.current_app.logger.exception(f"{message} \n {err}")  # Log the error
 

--- a/dds_web/commands.py
+++ b/dds_web/commands.py
@@ -679,9 +679,9 @@ def set_expired_to_archived():
                         project.current_deadline,
                     )
                     new_status_row, delete_message = archive.archive_project(
-                            project=project,
-                            current_time=current_time(),
-                        )
+                        project=project,
+                        current_time=current_time(),
+                    )
                     flask.current_app.logger.debug(delete_message.strip())
                     project.project_statuses.append(new_status_row)
 

--- a/dds_web/commands.py
+++ b/dds_web/commands.py
@@ -678,10 +678,24 @@ def set_expired_to_archived():
                         project.current_status,
                         project.current_deadline,
                     )
-                    new_status_row, delete_message = archive.archive_project(
-                        project=project,
-                        current_time=current_time(),
-                    )
+                    try:
+                        new_status_row, delete_message = archive.archive_project(
+                            project=project,
+                            current_time=current_time(),
+                        )
+                    except (
+                        sqlalchemy.exc.OperationalError,
+                        sqlalchemy.exc.SQLAlchemyError,
+                    ):
+                        # Save error message and continue to next project
+                        db.session.rollback()
+                        error_msg = (
+                            "Project bucket contents were deleted, but they were not deleted from the "
+                            "database. Please contact SciLifeLab Data Centre."
+                        )
+                        errors[unit.name][project.public_id] = error_msg
+                        continue
+
                     flask.current_app.logger.debug(delete_message.strip())
                     project.project_statuses.append(new_status_row)
 
@@ -694,6 +708,7 @@ def set_expired_to_archived():
                         sqlalchemy.exc.OperationalError,
                         sqlalchemy.exc.SQLAlchemyError,
                     ) as err:
+                        # commit operation failed, save error message, log it and continue to next project
                         flask.current_app.logger.exception(err)
                         db.session.rollback()
                         errors[unit.name][project.public_id] = str(err)

--- a/dds_web/commands.py
+++ b/dds_web/commands.py
@@ -681,9 +681,9 @@ def set_expired_to_archived():
                         project.current_status,
                         project.current_deadline,
                     )
-                    # If project is expired, delete the files and bucket
-                    # There could be a case where the expired project already has it's contents deleted
-                    # In this case create the new status directly
+                    # If project is expired, delete the files and bucket.
+                    # There could be a case where the expired project already has it's contents deleted.
+                    # In this case, calling the archive_project function should raise the error.
                     try:
                         new_status_row, delete_message = archive.archive_project(
                             project=project,
@@ -698,7 +698,7 @@ def set_expired_to_archived():
                         traceback = re.findall("raise.*?\\n", traceback)  # Get only the raise lines
                         for i in traceback:
                             if "BucketNotFoundError" in i:
-                                # If the error is a BucketNotFoundError, create the new status directly
+                                # If the real error is a BucketNotFoundError, create the new status directly
                                 new_status_row = models.ProjectStatuses(
                                     status="Archived", date_created=current_time(), is_aborted=False
                                 )

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -9,6 +9,8 @@ import logging
 import datetime
 import time
 import unittest.mock
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 # Installed
 import boto3
@@ -508,6 +510,49 @@ def test_projectstatus_archived_project(module_client, boto3_session):
         if field in fields_set_to_null:
             assert value
     assert project.researchusers
+
+
+def test_projectstatus_archived_project_db_fail(
+    module_client, boto3_session, capfd: LogCaptureFixture
+):
+    """Create a project and archive it fails in DB update"""
+
+    # Create unit admins to allow project creation
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    if current_unit_admins < 3:
+        create_unit_admins(num_admins=2)
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    assert current_unit_admins >= 3
+
+    response = module_client.post(
+        tests.DDSEndpoint.PROJECT_CREATE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(module_client),
+        json=proj_data,
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    project_id = response.json.get("project_id")
+
+    # change status and mock fail in DB operation
+    mock_query = MagicMock()
+    mock_query.filter.return_value.delete.side_effect = sqlalchemy.exc.OperationalError(
+        "OperationalError", "test", "sqlalchemy"
+    )
+    with patch("dds_web.database.models.File.query", mock_query):
+        new_status = {"new_status": "Archived"}
+        response = module_client.post(
+            tests.DDSEndpoint.PROJECT_STATUS,
+            headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+            query_string={"project": project_id},
+            json=new_status,
+        )
+        assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+
+    _, err = capfd.readouterr()
+    assert "DeletionError" in err
+    assert (
+        "Project bucket contents were deleted, but they were not deleted from the database. Please contact SciLifeLab Data Centre"
+        in err
+    )
 
 
 def test_projectstatus_aborted_project(module_client, boto3_session):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1400,12 +1400,6 @@ def test_set_expired_to_archived_db_failed(
     _: MagicMock, client, cli_runner, capfd: LogCaptureFixture
 ):
     """Reproduce the error when the s3 bucket is deleted but the DB update fails."""
-
-    def side_effect_generator():
-        yield RuntimeError("")  # First call, Error
-        while True:
-            yield None  # Subsequent calls, no exception
-
     # Get the project and set up as expired
     project = models.Project.query.filter_by(public_id="public_project_id").one_or_none()
     for status in project.project_statuses:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1395,6 +1395,36 @@ def test_set_expired_to_archived(_: MagicMock, client, cli_runner):
     assert j == 6
 
 
+@mock.patch("boto3.session.Session")
+def test_set_expired_to_archived_db_failed(
+    _: MagicMock, client, cli_runner, capfd: LogCaptureFixture
+):
+    """Reproduce the error when the s3 bucket is deleted but the DB update fails."""
+
+    def side_effect_generator():
+        yield RuntimeError("")  # First call, Error
+        while True:
+            yield None  # Subsequent calls, no exception
+
+    # Get the project and set up as expired
+    project = models.Project.query.filter_by(public_id="public_project_id").one_or_none()
+    for status in project.project_statuses:
+        status.deadline = current_time() - timedelta(weeks=1)
+        status.status = "Expired"
+
+    mock_query = MagicMock()
+    mock_query.filter.return_value.delete.side_effect = sqlalchemy.exc.OperationalError(
+        "OperationalError", "test", "sqlalchemy"
+    )
+    with patch("dds_web.database.models.File.query", mock_query):
+        with patch("flask.request", False):
+            cli_runner.invoke(set_expired_to_archived)
+
+    # Check the logs for the error message
+    _, err = capfd.readouterr()
+    assert ("SQL: OperationalError") in err
+
+
 # delete invites
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1396,7 +1396,9 @@ def test_set_expired_to_archived(_: MagicMock, client, cli_runner):
 
 
 @mock.patch("boto3.session.Session")
-def test_set_expired_to_archived_db_failed(_: MagicMock, client, cli_runner):
+def test_set_expired_to_archived_db_failed(
+    _: MagicMock, client, cli_runner, capfd: LogCaptureFixture
+):
     """Reproduce the error when the s3 bucket is deleted but the DB update fails."""
     import re
 
@@ -1418,7 +1420,25 @@ def test_set_expired_to_archived_db_failed(_: MagicMock, client, cli_runner):
         with patch.object(re, "findall") as regex:
             regex.return_value = ["BucketNotFoundError"]
             cli_runner.invoke(set_expired_to_archived)
-    assert project.current_status == "Archived"
+
+    # Check the logs for the error message
+    _, err = capfd.readouterr()
+    assert "BucketNotFoundError: No bucket found for the specified project" in err
+
+    # Mock again with a DeletionError instead archive_project method to raise an error
+    with patch("dds_web.api.project.ProjectStatus.archive_project") as mock_archive_project:
+        mock_archive_project.side_effect = side_effect_generator()
+        # Mock that the regex to query the traceback found a DeletionError
+        with patch.object(re, "findall") as regex:
+            regex.return_value = ["DeletionError"]
+            cli_runner.invoke(set_expired_to_archived)
+
+    # Check the logs for the error message
+    _, err = capfd.readouterr()
+    assert (
+        "DeletionError: Project bucket contents were deleted, but they were not deleted from the "
+    )
+    "database. Please contact SciLifeLab Data Centre." in err
 
 
 # delete invites

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1395,6 +1395,33 @@ def test_set_expired_to_archived(_: MagicMock, client, cli_runner):
     assert j == 6
 
 
+@mock.patch("boto3.session.Session")
+def test_set_expired_to_archived_db_failed(_: MagicMock, client, cli_runner):
+    """Reproduce the error when the s3 bucket is deleted but the DB update fails."""
+    from tests.api.test_project import mock_sqlalchemyerror
+
+    project = models.Project.query.filter_by(public_id="public_project_id").one_or_none()
+
+    for status in project.project_statuses:
+        status.deadline = current_time() - timedelta(weeks=1)
+        status.status = "Expired"
+    # Do the first call that just deletes the s3 bucket but does not update the database
+    # either mock the db update or call the deletion directly
+
+    #    with patch("dds_web.db.session.commit", mock_sqlalchemyerror):
+    #        cli_runner.invoke(set_expired_to_archived)
+    from dds_web.api.project import RemoveContents
+
+    RemoveContents().delete_project_contents(project=project, delete_bucket=True)
+
+    # TODO check that bucket does not exist but db is not updated
+    assert project.current_status == "Expired"
+
+    # Do the second call that updates the database but will not fail when bucket not found
+    cli_runner.invoke(set_expired_to_archived)
+    assert project.current_status == "Archived"
+
+
 # delete invites
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1416,6 +1416,10 @@ def test_set_expired_to_archived_db_failed(
 
     # Check the logs for the error message
     _, err = capfd.readouterr()
+    print(err)
+    assert (
+        "Project bucket contents were deleted, but they were not deleted from the database. Please contact SciLifeLab Data Centre."
+    ) in err
     assert ("SQL: OperationalError") in err
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1395,52 +1395,6 @@ def test_set_expired_to_archived(_: MagicMock, client, cli_runner):
     assert j == 6
 
 
-@mock.patch("boto3.session.Session")
-def test_set_expired_to_archived_db_failed(
-    _: MagicMock, client, cli_runner, capfd: LogCaptureFixture
-):
-    """Reproduce the error when the s3 bucket is deleted but the DB update fails."""
-    import re
-
-    def side_effect_generator():
-        yield RuntimeError("")  # First call, Error
-        while True:
-            yield None  # Subsequent calls, no exception
-
-    # Get the project and set up as expired
-    project = models.Project.query.filter_by(public_id="public_project_id").one_or_none()
-    for status in project.project_statuses:
-        status.deadline = current_time() - timedelta(weeks=1)
-        status.status = "Expired"
-
-    # Mock the archive_project method to raise an error
-    with patch("dds_web.api.project.ProjectStatus.archive_project") as mock_archive_project:
-        mock_archive_project.side_effect = side_effect_generator()
-        # Mock that the regex to query the traceback found a BucketNotFoundError
-        with patch.object(re, "findall") as regex:
-            regex.return_value = ["BucketNotFoundError"]
-            cli_runner.invoke(set_expired_to_archived)
-
-    # Check the logs for the error message
-    _, err = capfd.readouterr()
-    assert "BucketNotFoundError: No bucket found for the specified project" in err
-
-    # Mock again with a DeletionError instead archive_project method to raise an error
-    with patch("dds_web.api.project.ProjectStatus.archive_project") as mock_archive_project:
-        mock_archive_project.side_effect = side_effect_generator()
-        # Mock that the regex to query the traceback found a DeletionError
-        with patch.object(re, "findall") as regex:
-            regex.return_value = ["DeletionError"]
-            cli_runner.invoke(set_expired_to_archived)
-
-    # Check the logs for the error message
-    _, err = capfd.readouterr()
-    assert (
-        "DeletionError: Project bucket contents were deleted, but they were not deleted from the "
-    )
-    "database. Please contact SciLifeLab Data Centre." in err
-
-
 # delete invites
 
 


### PR DESCRIPTION
## Read this before submitting the PR

1. Always create a Draft PR first
2. Go through sections 1-5 below, fill them in and check all the boxes
3. Make sure that the branch is updated; if there's an "Update branch" button at the bottom of the PR, rebase or update branch.
4. When all boxes are checked, information is filled in, and the branch is updated: mark as Ready For Review and tag reviewers (top right)
5. Once there is a submitted review, implement the suggestions (if reasonable, otherwise discuss) and request an new review.

If there is a field which you are unsure about, enter the edit mode of this description or go to the [PR template](../.github/pull_request_template.md); There are invisible comments providing descriptions which may be of help.

## 1. Description / Summary

Fix raising of error when bucket successfully deleted from S3 but DB update fails

--- **To reproduce** ---

Add a few lines for the application to sleep
- Line 754 in api/project.py
```
            import time
            flask.current_app.logger.debug("Sleeping for 15 seconds.")
            time.sleep(15)
```


Release from the client project_1 and update the database to change the deadline. A _testbucket_ has to exit in Minio

`UPDATE projectstatuses SET deadline = CURDATE() - INTERVAL 1 DAY where project_id = 1;`

Expire the project from backend container

`flask set-available-to-expired`

And update the deadline again


**1.  From the flask command (cronjob)**

Add a second waiting time, after the else. In order to be able to turn on the db again and continue for the next projects.

Run
` flask set-expired-to-archived`

And during the 15 seconds stop. Stop the mariadb container, the error got must be a 

`sqlalchemy.exc.OperationalError: (pymysql.err.OperationalError) (2013, 'Lost connection to MySQL server during query')`

i.e. The error throw if not from a request

**2.  From a request**

Add another time stop in 774. After the line that catches the sqlerror and before creating the DeletionError 

```
            if flask.request:
                flask.current_app.logger.debug("Sleeping for 15 seconds.")
                time.sleep(15)
                raise DeletionError(
```

That is, because, if the db is still stopped when trying to throw the exception. There will be a different error thown.

Remember to recreate the testbucket in Minio

From the client, run the command to expire the project, with the db container up.

During the first 15-second wait, stop the container to force the exception.

During the second 15 seconds wait, start the container again to be able to communicate with the client and return the error.

The command will fail in the client, and in the logs it can be seen that the DeletionError was generated.




## 2. Jira task / GitHub issue

[_Link to the github issue or add the Jira task ID here._](https://scilifelab.atlassian.net/jira/software/projects/DDS/boards/13?selectedIssue=DDS-1920)

## 3. Type of change

What _type of change(s)_ does the PR contain?

**Check the relevant boxes below. For an explanation of the different sections, enter edit mode of this PR description template.**

- [x] New feature
  - [ ] Breaking: _Why / How? Add info here._ <!-- Should be checked if the changes in this PR will cause existing functionality to not work as expected. E.g. with the master branch of the `dds_cli` -->
  - [x] Non-breaking <!-- Should be checked if the changes will not cause existing functionality to fail. "Non-breaking" is just an addition of a new feature. -->
- [ ] Database change: _Remember the to include a new migration version, **or** explain here why it's not needed._ <!-- Should be checked when you've changed something in `models.py`. For a guide on how to add the a new migration version, look at the "Database changes" section in the README.md. -->
- [ ] Bug fix <!-- Should be checked when a bug is fixed in existing functionality. If the bug fix also is a breaking change (see above), add info about that beside this check box. -->
- [ ] Security Alert fix <!-- Should be checked if the PR attempts to solve a security vulnerability, e.g. reported by the "Security" tab in the repo. -->
  - [ ] Package update <!-- Should be checked if the Security alert fix consists of updating a package / dependency version -->
    - [ ] Major version update <!-- Should be checked if the package / dependency version update is a major upgrade, e.g. 1.0.0 to 2.0.0 -->
- [ ] Documentation <!-- Should be checked if the PR adds or updates documentation such as e.g. Technical Overview or a architecture decision (dds_web/doc/architecture/decisions.) -->
- [ ] Workflow <!-- Should be checked if the PR includes a change in e.g. the github actions files (dds_web/.github/*) or another type of workflow change. Anything that alters our or the codes workflow. -->
- [ ] Tests **only** <!-- Should only be checked if the PR only contains tests, none of the other types of changes listed above. -->

## 4. Additional information

- [x] [Sprintlog](../SPRINTLOG.md) <!-- Add a row at the bottom of the SPRINTLOG.md file (not needed if PR contains only tests). Follow the format of previous rows. If the PR is the first in a new sprint, add a new sprint header row (follow the format of previous sprints). -->
- [ ] Blocking PRs <!-- Should be checked if there are blocking PRs or other tasks that need to be merged prior to this. Add link to PR or Jira card if this is the case. -->
  - [ ] Merged <!-- Should be checked if the "Blocking PRs" box was checked AND all blocking PRs have been merged / fixed. -->
- [ ] PR to `master` branch: \_If checked, read [the release instructions](../doc/procedures/new_release.md) <!-- Check this if the PR is made to the `master` branch. Only the `dev` branch should be doing this. -->
  - [ ] I have followed steps 1-8. <!-- Should be checked if the "PR to `master` branch" box is checked AND the specified steps in the release instructions have been followed. -->

## 5. Actions / Scans

_Check the boxes when the specified checks have passed._

**For information on what the different checks do and how to fix it if they're failing, enter edit mode of this description or go to the [PR template](../.github/pull_request_template.md).**

- [x] **Black**
<!--
  What: Python code formatter.
  How to fix: Run `black .` locally to execute formatting.
-->
- [x] **Prettier**
<!--
  What: General code formatter. Our use case: MD and yaml mainly.
  How to fix: Run npx prettier --write . locally to execute formatting.
-->
- [x] **Yamllint**
<!--
  What: Linting of yaml files.
  How to fix: Manually fix any errors locally.
-->
- [x] **Tests**
<!--
  What: Pytest to verify that functionality works as expected.
  How to fix: Manually fix any errors locally. Follow the instructions in the "Run tests" section of the README.md to run the tests locally.
  Additional info: The PR should ALWAYS include new tests or fixed tests when there are code changes. When pytest action has finished, it will post a codecov report; Look at this report and verify the files you have changed are listed. "90% <100.00%> (+0.8%)" means "Tests cover 90% of the changed file, <100 % of this PR's code changes are tested>, and (the code changes and added tests increased the overall test coverage with 0.8%)
-->
- [x] **CodeQL**
<!--
  What: Scan for security vulnerabilities, bugs, errors.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [x] **Trivy**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [x] **Snyk**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
