### PR TITLE
Feature/optional sto4 timestamp update

### DIFF
--- a/dds_web/commands.py
+++ b/dds_web/commands.py
@@ -163,8 +163,15 @@ def create_new_unit(
 @click.option("--sto4-name", "-sn", type=str, required=True)
 @click.option("--sto4-access", "-sa", type=str, required=True)
 @click.option("--sto4-secret", "-ss", type=str, required=True)
+@click.option(
+    "--skip-timestamp",
+    "-st",
+    is_flag=True,
+    default=False,
+    help="Skip updating the sto4_start_time timestamp",
+)
 @flask.cli.with_appcontext
-def update_unit_sto4(unit_id, sto4_endpoint, sto4_name, sto4_access, sto4_secret):
+def update_unit_sto4(unit_id, sto4_endpoint, sto4_name, sto4_access, sto4_secret, skip_timestamp):
     """Update unit sto4 storage info."""
     # Imports
     import rich.prompt
@@ -188,7 +195,8 @@ def update_unit_sto4(unit_id, sto4_endpoint, sto4_name, sto4_access, sto4_secret
             return
 
     # Set sto4 info
-    unit.sto4_start_time = current_time()
+    if not skip_timestamp:  # Update timestamp by default unless explicitly skipped
+        unit.sto4_start_time = current_time()
     unit.sto4_endpoint = sto4_endpoint
     unit.sto4_name = sto4_name
     unit.sto4_access = sto4_access


### PR DESCRIPTION
## 1. Description / Summary
Add `--skip-timestamp` flag to the `update-unit-sto4` command. This flag allows updating STO4 endpoint information without modifying the `sto4_start_time`. By default (without the flag), the command maintains its existing behavior of updating the timestamp.

**Add a summary here**: What does this PR add/change and why?

## 2. Jira task / GitHub issue

**Is this a GitHub issue?** --> Add the link to the github issue

**Is this from a Jira task?** --> If your branch does not contain info regarding the Jira task ID, put it here.

## 3. Type of change - Add label
- [x] New feature
  - [ ] Breaking: _Why / How? Add info here._ <!-- Should be checked if the changes in this PR will cause existing functionality to not work as expected. E.g. with the master branch of the `dds_cli` -->
  - [x] Non-breaking <!-- Should be checked if the changes will not cause existing functionality to fail. "Non-breaking" is just an addition of a new feature. -->
- [ ] Database change: _Remember the to include a new migration version, **or** explain here why it's not needed._ <!-- Should be checked when you've changed something in `models.py`. For a guide on how to add the a new migration version, look at the "Database changes" section in the README.md. -->
- [ ] Bug fix <!-- Should be checked when a bug is fixed in existing functionality. If the bug fix also is a breaking change (see above), add info about that beside this check box. -->
- [ ] Security Alert fix <!-- Should be checked if the PR attempts to solve a security vulnerability, e.g. reported by the "Security" tab in the repo. -->
  - [ ] Package update <!-- Should be checked if the Security alert fix consists of updating a package / dependency version -->
    - [ ] Major version update <!-- Should be checked if the package / dependency version update is a major upgrade, e.g. 1.0.0 to 2.0.0 -->
- [ ] Documentation <!-- Should be checked if the PR adds or updates documentation such as e.g. Technical Overview or a architecture decision (dds_web/doc/architecture/decisions.) -->
- [ ] Workflow <!-- Should be checked if the PR includes a change in e.g. the github actions files (dds_web/.github/*) or another type of workflow change. Anything that alters our or the codes workflow. -->
- [ ] Tests **only** <!-- Should only be checked if the PR only contains tests, none of the other types of changes listed above. -->
## 4. Additional information

- [ ] I have added an entry to the [Sprintlog](../SPRINTLOG.md) <!-- Add a row at the bottom of the SPRINTLOG.md file (not needed if PR contains only tests). Follow the format of previous rows. If the PR is the first in a new sprint, add a new sprint header row (follow the format of previous sprints). -->
- [ ] This is a PR to the `master` branch: _If checked, read [the release instructions](../doc/procedures/new_release.md)_ <!-- Check this if the PR is made to the `master` branch. Only the `dev` branch should be doing this. -->
  - [ ] I have followed steps 1-8. <!-- Should be checked if the "PR to `master` branch" box is checked AND the specified steps in the release instructions have been followed. -->

## 5. Actions / Scans


_Check the boxes when the specified checks have passed._

**For information on what the different checks do and how to fix it if they're failing, enter edit mode of this description or go to the [PR template](../.github/pull_request_template.md).**

- [x] **Black**
<!--
  What: Python code formatter.
  How to fix: Run `black .` locally to execute formatting.
-->
- [x] **Prettier**
<!--
  What: General code formatter. Our use case: MD and yaml mainly.
  How to fix: Run npx prettier --write . locally to execute formatting.
-->
- [x] **Yamllint**
<!--
  What: Linting of yaml files.
  How to fix: Manually fix any errors locally.
-->
- [x] **Tests**
<!--
  What: Pytest to verify that functionality works as expected.
  How to fix: Manually fix any errors locally. Follow the instructions in the "Run tests" section of the README.md to run the tests locally.
  Additional info: The PR should ALWAYS include new tests or fixed tests when there are code changes. When pytest action has finished, it will post a codecov report; Look at this report and verify the files you have changed are listed. "90% <100.00%> (+0.8%)" means "Tests cover 90% of the changed file, <100 % of this PR's code changes are tested>, and (the code changes and added tests increased the overall test coverage with 0.8%)
-->
- [x] **CodeQL**
<!--
  What: Scan for security vulnerabilities, bugs, errors.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [x] **Trivy**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- [x] **Snyk**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
