### PR TITLE
Move project inactivation to after data-removal in order to ensure projects cannot be inactive while still containing data

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -494,6 +494,5 @@ _Nothing merged during this sprint_
 
 # 2025-05-12 - 2025-05-23
 
-
 - New Github Action for automatically creating release draft: Release Drafter ([#1604](https://github.com/ScilifelabDataCentre/dds_web/pull/1604))
 - Improve set-expired-to-archived command to insure project are not inactivated without being deleted ([#1605](https://github.com/ScilifelabDataCentre/dds_web/pull/1605))

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -491,3 +491,7 @@ _Nothing merged during this sprint_
 
 - Set MOTD as a background task([#1594](https://github.com/ScilifelabDataCentre/dds_web/pull/1594))
 - Remove docker-compose.yml version (obsolete) ([#1598](https://github.com/ScilifelabDataCentre/dds_web/pull/1598))
+
+# 2025-05-12 - 2025-05-23
+
+- Improve set-expired-to-archived command to insure project are not inactivated without being deleted ([#1605](https://github.com/ScilifelabDataCentre/dds_web/pull/1605))

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -485,11 +485,11 @@ class ProjectStatus(flask_restful.Resource):
             )
             self.rm_project_user_keys(project=project)
 
+            # Only mark as inactive after all deletion operations succeed
+            project.is_active = False
             # Delete metadata from project row
             self.delete_project_info(proj=project)
 
-            # Only mark as inactive after all deletion operations succeed
-            project.is_active = False
         except (TypeError, DatabaseError, DeletionError, BucketNotFoundError) as err:
             flask.current_app.logger.exception(err)
             db.session.rollback()
@@ -530,13 +530,13 @@ class ProjectStatus(flask_restful.Resource):
             delete_message = f"\nAll files in {project.public_id} deleted"
             self.rm_project_user_keys(project=project)
 
+            # Only mark as inactive after all deletion operations succeed
+            project.is_active = False
             # Delete metadata from project row
             if aborted:
                 project = self.delete_project_info(project)
                 delete_message += " and project info cleared"
 
-            # Only mark as inactive after all deletion operations succeed
-            project.is_active = False
         except (TypeError, DatabaseError, DeletionError, BucketNotFoundError) as err:
             flask.current_app.logger.exception(err)
             db.session.rollback()

--- a/dds_web/api/project.py
+++ b/dds_web/api/project.py
@@ -477,7 +477,6 @@ class ProjectStatus(flask_restful.Resource):
                 "You cannot delete a project that has been made available previously. "
                 "Please abort the project if you wish to proceed."
             )
-        project.is_active = False
 
         try:
             # Deletes files (also commits session in the function - possibly refactor later)
@@ -488,6 +487,9 @@ class ProjectStatus(flask_restful.Resource):
 
             # Delete metadata from project row
             self.delete_project_info(proj=project)
+
+            # Only mark as inactive after all deletion operations succeed
+            project.is_active = False
         except (TypeError, DatabaseError, DeletionError, BucketNotFoundError) as err:
             flask.current_app.logger.exception(err)
             db.session.rollback()
@@ -519,7 +521,6 @@ class ProjectStatus(flask_restful.Resource):
                     "You cannot archive a project that has been made available previously. "
                     "Please abort the project if you wish to proceed."
                 )
-        project.is_active = False
 
         try:
             # Deletes files (also commits session in the function - possibly refactor later)
@@ -533,6 +534,9 @@ class ProjectStatus(flask_restful.Resource):
             if aborted:
                 project = self.delete_project_info(project)
                 delete_message += " and project info cleared"
+
+            # Only mark as inactive after all deletion operations succeed
+            project.is_active = False
         except (TypeError, DatabaseError, DeletionError, BucketNotFoundError) as err:
             flask.current_app.logger.exception(err)
             db.session.rollback()

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -116,23 +116,30 @@ def test_project(module_client):
 def mock_sqlalchemyerror(_=None):
     raise sqlalchemy.exc.SQLAlchemyError()
 
+
 def mock_typeerror(_=None):
     raise TypeError
+
 
 def mock_databaseerror(_=None):
     raise DatabaseError
 
+
 def mock_deletionerror(_=None):
     raise DeletionError()
+
 
 def mock_bucketnotfounderror(_=None):
     raise BucketNotFoundError()
 
+
 def mock_operationalerror(_=None):
     raise sqlalchemy.exc.OperationalError
 
+
 def mock_attributeerror():
     raise AttributeError
+
 
 # ProjectStatus
 

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -116,6 +116,23 @@ def test_project(module_client):
 def mock_sqlalchemyerror(_=None):
     raise sqlalchemy.exc.SQLAlchemyError()
 
+def mock_typeerror(_=None):
+    raise TypeError
+
+def mock_databaseerror(_=None):
+    raise DatabaseError
+
+def mock_deletionerror(_=None):
+    raise DeletionError()
+
+def mock_bucketnotfounderror(_=None):
+    raise BucketNotFoundError()
+
+def mock_operationalerror(_=None):
+    raise sqlalchemy.exc.OperationalError
+
+def mock_attributeerror():
+    raise AttributeError
 
 # ProjectStatus
 
@@ -1519,18 +1536,6 @@ def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3
     project_id = response.json.get("project_id")
     project = project_row(project_id=project_id)
 
-    def mock_typeerror():
-        raise TypeError
-
-    def mock_databaseerror():
-        raise DatabaseError
-
-    def mock_deletionerror():
-        raise DeletionError()
-
-    def mock_bucketnotfounderror():
-        raise BucketNotFoundError()
-
     for func in [mock_typeerror, mock_databaseerror, mock_deletionerror, mock_bucketnotfounderror]:
         with unittest.mock.patch("dds_web.api.project.ProjectStatus.delete_project_info", func):
             response = module_client.post(
@@ -1560,18 +1565,6 @@ def test_projectstatus_failed_delete_project_content(module_client, boto3_sessio
     assert response.status_code == http.HTTPStatus.OK
     project_id = response.json.get("project_id")
     project = project_row(project_id=project_id)
-
-    def mock_deletionerror():
-        raise DeletionError()
-
-    def mock_sqlalchemyerror():
-        raise sqlalchemy.exc.SQLAlchemyError
-
-    def mock_operationalerror():
-        raise sqlalchemy.exc.OperationalError
-
-    def mock_attributeerror():
-        raise AttributeError
 
     for func in [
         mock_deletionerror,
@@ -1609,12 +1602,6 @@ def test_projectstatus_failed_rm_project_user_keys(module_client, boto3_session)
     assert response.status_code == http.HTTPStatus.OK
     project_id = response.json.get("project_id")
     project = project_row(project_id=project_id)
-
-    def mock_sqlalchemyerror():
-        raise sqlalchemy.exc.SQLAlchemyError
-
-    def mock_operationalerror():
-        raise sqlalchemy.exc.OperationalError
 
     for func in [mock_sqlalchemyerror, mock_operationalerror]:
         with unittest.mock.patch("dds_web.api.project.ProjectStatus.rm_project_user_keys", func):
@@ -1705,18 +1692,6 @@ def test_projectstatus_released_post_deletion_and_archivation_errors(module_clie
         json={"new_status": "Available"},
     )
     assert response.status_code == http.HTTPStatus.OK
-
-    def mock_typeerror():
-        raise TypeError
-
-    def mock_databaseerror():
-        raise DatabaseError
-
-    def mock_deletionerror():
-        raise DeletionError()
-
-    def mock_bucketnotfounderror():
-        raise BucketNotFoundError()
 
     for func in [mock_typeerror, mock_databaseerror, mock_deletionerror, mock_bucketnotfounderror]:
         with unittest.mock.patch("dds_web.api.project.ProjectStatus.delete_project_info", func):

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -531,6 +531,7 @@ def test_projectstatus_archived_project_db_fail(
     )
     assert response.status_code == http.HTTPStatus.OK
     project_id = response.json.get("project_id")
+    project = project_row(project_id=project_id)
 
     # change status and mock fail in DB operation
     mock_query = MagicMock()
@@ -554,6 +555,7 @@ def test_projectstatus_archived_project_db_fail(
         in err
     )
 
+    assert project.is_active
 
 def test_projectstatus_aborted_project(module_client, boto3_session):
     """Create a project and try to abort it"""
@@ -1046,6 +1048,7 @@ def test_projectstatus_set_project_to_archived(module_client, test_project, boto
     assert not max(project.project_statuses, key=lambda x: x.date_created).is_aborted
     assert not file_in_db(test_dict=FIRST_NEW_FILE, project=project.id)
     assert not project.project_user_keys
+    assert not project.is_active
 
 
 def test_projectstatus_invalid_transitions_from_archived(module_client, test_project):
@@ -1529,7 +1532,6 @@ def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3
 
     for func in [mock_typeerror, mock_databaseerror, mock_deletionerror, mock_bucketnotfounderror]:
         with unittest.mock.patch("dds_web.api.project.ProjectStatus.delete_project_info", func):
-            # Release project
             response = module_client.post(
                 tests.DDSEndpoint.PROJECT_STATUS,
                 headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
@@ -1538,6 +1540,84 @@ def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3
             )
             assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
             assert "Server Error: Status was not updated" in response.json["message"]
+            assert project.is_active
+
+
+def test_projectstatus_failed_delete_project_content(module_client, boto3_session):
+    """Mock the different expections that can occur when deleting project."""
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    if current_unit_admins < 3:
+        create_unit_admins(num_admins=2)
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    assert current_unit_admins >= 3
+
+    response = module_client.post(
+        tests.DDSEndpoint.PROJECT_CREATE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(module_client),
+        json=proj_data,
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    project_id = response.json.get("project_id")
+    project = project_row(project_id=project_id)
+
+    def mock_deletionerror():
+        raise DeletionError()
+
+    def mock_sqlalchemyerror():
+        raise sqlalchemy.exc.SQLAlchemyError
+
+    def mock_operationalerror():
+        raise sqlalchemy.exc.OperationalError
+
+    def mock_attributeerror():
+        raise AttributeError
+    for func in [mock_deletionerror, mock_sqlalchemyerror, mock_operationalerror, mock_attributeerror]:
+        with unittest.mock.patch("dds_web.api.project.RemoveContents.delete_project_contents", func):
+            response = module_client.post(
+                tests.DDSEndpoint.PROJECT_STATUS,
+                headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+                query_string={"project": project_id},
+                json={"new_status": "Deleted"},
+            )
+            assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+            assert "Server Error: Status was not updated" in response.json["message"]
+            assert project.is_active
+
+
+def test_projectstatus_failed_rm_project_user_keys(module_client, boto3_session):
+    """Mock the different expections that can occur when deleting project."""
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    if current_unit_admins < 3:
+        create_unit_admins(num_admins=2)
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    assert current_unit_admins >= 3
+
+    response = module_client.post(
+        tests.DDSEndpoint.PROJECT_CREATE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(module_client),
+        json=proj_data,
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    project_id = response.json.get("project_id")
+    project = project_row(project_id=project_id)
+
+    def mock_sqlalchemyerror():
+        raise sqlalchemy.exc.SQLAlchemyError
+
+    def mock_operationalerror():
+        raise sqlalchemy.exc.OperationalError
+
+    for func in [mock_sqlalchemyerror, mock_operationalerror]:
+        with unittest.mock.patch("dds_web.api.project.ProjectStatus.rm_project_user_keys", func):
+            response = module_client.post(
+                tests.DDSEndpoint.PROJECT_STATUS,
+                headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+                query_string={"project": project_id},
+                json={"new_status": "Deleted"},
+            )
+            assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+            assert "Server Error: Status was not updated" in response.json["message"]
+            assert project.is_active
 
 
 def test_projectstatus_post_archiving_without_aborting(module_client, boto3_session):
@@ -1591,7 +1671,7 @@ def test_projectstatus_post_archiving_without_aborting(module_client, boto3_sess
     )
 
 
-def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3_session):
+def test_projectstatus_released_post_deletion_and_archivation_errors(module_client, boto3_session):
     """Mock the different expections that can occur when deleting project."""
     current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
     if current_unit_admins < 3:
@@ -1608,6 +1688,7 @@ def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3
     project_id = response.json.get("project_id")
     project = project_row(project_id=project_id)
 
+    # Release project
     response = module_client.post(
         tests.DDSEndpoint.PROJECT_STATUS,
         headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
@@ -1630,7 +1711,6 @@ def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3
 
     for func in [mock_typeerror, mock_databaseerror, mock_deletionerror, mock_bucketnotfounderror]:
         with unittest.mock.patch("dds_web.api.project.ProjectStatus.delete_project_info", func):
-            # Release project
             response = module_client.post(
                 tests.DDSEndpoint.PROJECT_STATUS,
                 headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
@@ -1639,7 +1719,7 @@ def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3
             )
             assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
             assert "Server Error: Status was not updated" in response.json["message"]
-
+            assert project.is_active
 
 # GetPublic
 

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -557,6 +557,7 @@ def test_projectstatus_archived_project_db_fail(
 
     assert project.is_active
 
+
 def test_projectstatus_aborted_project(module_client, boto3_session):
     """Create a project and try to abort it"""
     # Create unit admins to allow project creation
@@ -1571,8 +1572,16 @@ def test_projectstatus_failed_delete_project_content(module_client, boto3_sessio
 
     def mock_attributeerror():
         raise AttributeError
-    for func in [mock_deletionerror, mock_sqlalchemyerror, mock_operationalerror, mock_attributeerror]:
-        with unittest.mock.patch("dds_web.api.project.RemoveContents.delete_project_contents", func):
+
+    for func in [
+        mock_deletionerror,
+        mock_sqlalchemyerror,
+        mock_operationalerror,
+        mock_attributeerror,
+    ]:
+        with unittest.mock.patch(
+            "dds_web.api.project.RemoveContents.delete_project_contents", func
+        ):
             response = module_client.post(
                 tests.DDSEndpoint.PROJECT_STATUS,
                 headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
@@ -1720,6 +1729,7 @@ def test_projectstatus_released_post_deletion_and_archivation_errors(module_clie
             assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
             assert "Server Error: Status was not updated" in response.json["message"]
             assert project.is_active
+
 
 # GetPublic
 

--- a/tests/tests_v3/api/test_project.py
+++ b/tests/tests_v3/api/test_project.py
@@ -9,6 +9,8 @@ import logging
 import datetime
 import time
 import unittest.mock
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 # Installed
 import boto3
@@ -114,6 +116,23 @@ def test_project(module_client):
 def mock_sqlalchemyerror(_=None):
     raise sqlalchemy.exc.SQLAlchemyError()
 
+def mock_typeerror(_=None):
+    raise TypeError
+
+def mock_databaseerror(_=None):
+    raise DatabaseError
+
+def mock_deletionerror(_=None):
+    raise DeletionError()
+
+def mock_bucketnotfounderror(_=None):
+    raise BucketNotFoundError()
+
+def mock_operationalerror(_=None):
+    raise sqlalchemy.exc.OperationalError
+
+def mock_attributeerror():
+    raise AttributeError
 
 # ProjectStatus
 
@@ -509,6 +528,51 @@ def test_projectstatus_archived_project(module_client, boto3_session):
             assert value
     assert project.researchusers
 
+
+def test_projectstatus_archived_project_db_fail(
+    module_client, boto3_session, capfd: LogCaptureFixture
+):
+    """Create a project and archive it fails in DB update"""
+
+    # Create unit admins to allow project creation
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    if current_unit_admins < 3:
+        create_unit_admins(num_admins=2)
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    assert current_unit_admins >= 3
+
+    response = module_client.post(
+        tests.DDSEndpoint.PROJECT_CREATE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(module_client),
+        json=proj_data,
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    project_id = response.json.get("project_id")
+    project = project_row(project_id=project_id)
+
+    # change status and mock fail in DB operation
+    mock_query = MagicMock()
+    mock_query.filter.return_value.delete.side_effect = sqlalchemy.exc.OperationalError(
+        "OperationalError", "test", "sqlalchemy"
+    )
+    with patch("dds_web.database.models.File.query", mock_query):
+        new_status = {"new_status": "Archived"}
+        response = module_client.post(
+            tests.DDSEndpoint.PROJECT_STATUS,
+            headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+            query_string={"project": project_id},
+            json=new_status,
+        )
+        assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+
+    _, err = capfd.readouterr()
+    assert "DeletionError" in err
+    assert (
+        "Project bucket contents were deleted, but they were not deleted from the database. Please contact SciLifeLab Data Centre"
+        in err
+    )
+
+    assert project.is_active
 
 def test_projectstatus_aborted_project(module_client, boto3_session):
     """Create a project and try to abort it"""
@@ -1000,6 +1064,7 @@ def test_projectstatus_set_project_to_archived(module_client, test_project, boto
     assert not max(project.project_statuses, key=lambda x: x.date_created).is_aborted
     assert not file_in_db(test_dict=FIRST_NEW_FILE, project=project.id)
     assert not project.project_user_keys
+    assert not project.is_active
 
 
 def test_projectstatus_invalid_transitions_from_archived(module_client, test_project):
@@ -1469,21 +1534,8 @@ def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3
     project_id = response.json.get("project_id")
     project = project_row(project_id=project_id)
 
-    def mock_typeerror():
-        raise TypeError
-
-    def mock_databaseerror():
-        raise DatabaseError
-
-    def mock_deletionerror():
-        raise DeletionError()
-
-    def mock_bucketnotfounderror():
-        raise BucketNotFoundError()
-
     for func in [mock_typeerror, mock_databaseerror, mock_deletionerror, mock_bucketnotfounderror]:
         with unittest.mock.patch("dds_web.api.project.ProjectStatus.delete_project_info", func):
-            # Release project
             response = module_client.post(
                 tests.DDSEndpoint.PROJECT_STATUS,
                 headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
@@ -1492,6 +1544,73 @@ def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3
             )
             assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
             assert "Server Error: Status was not updated" in response.json["message"]
+            assert project.is_active
+
+
+def test_projectstatus_failed_delete_project_content(module_client, boto3_session):
+    """Mock the different expections that can occur when deleting project."""
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    if current_unit_admins < 3:
+        create_unit_admins(num_admins=2)
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    assert current_unit_admins >= 3
+
+    response = module_client.post(
+        tests.DDSEndpoint.PROJECT_CREATE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(module_client),
+        json=proj_data,
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    project_id = response.json.get("project_id")
+    project = project_row(project_id=project_id)
+
+    for func in [
+        mock_deletionerror,
+        mock_sqlalchemyerror,
+        mock_operationalerror,
+        mock_attributeerror,
+    ]:
+        with unittest.mock.patch(
+            "dds_web.api.project.RemoveContents.delete_project_contents", func
+        ):
+            response = module_client.post(
+                tests.DDSEndpoint.PROJECT_STATUS,
+                headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+                query_string={"project": project_id},
+                json={"new_status": "Deleted"},
+            )
+            assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+            assert "Server Error: Status was not updated" in response.json["message"]
+            assert project.is_active
+
+def test_projectstatus_failed_rm_project_user_keys(module_client, boto3_session):
+    """Mock the different expections that can occur when deleting project."""
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    if current_unit_admins < 3:
+        create_unit_admins(num_admins=2)
+    current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
+    assert current_unit_admins >= 3
+
+    response = module_client.post(
+        tests.DDSEndpoint.PROJECT_CREATE,
+        headers=tests.UserAuth(tests.USER_CREDENTIALS["unituser"]).token(module_client),
+        json=proj_data,
+    )
+    assert response.status_code == http.HTTPStatus.OK
+    project_id = response.json.get("project_id")
+    project = project_row(project_id=project_id)
+
+    for func in [mock_sqlalchemyerror, mock_operationalerror]:
+        with unittest.mock.patch("dds_web.api.project.ProjectStatus.rm_project_user_keys", func):
+            response = module_client.post(
+                tests.DDSEndpoint.PROJECT_STATUS,
+                headers=tests.UserAuth(tests.USER_CREDENTIALS["unitadmin"]).token(module_client),
+                query_string={"project": project_id},
+                json={"new_status": "Deleted"},
+            )
+            assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+            assert "Server Error: Status was not updated" in response.json["message"]
+            assert project.is_active
 
 
 def test_projectstatus_post_archiving_without_aborting(module_client, boto3_session):
@@ -1545,7 +1664,7 @@ def test_projectstatus_post_archiving_without_aborting(module_client, boto3_sess
     )
 
 
-def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3_session):
+def test_projectstatus_released_post_deletion_and_archivation_errors(module_client, boto3_session):
     """Mock the different expections that can occur when deleting project."""
     current_unit_admins = models.UnitUser.query.filter_by(unit_id=1, is_admin=True).count()
     if current_unit_admins < 3:
@@ -1570,18 +1689,6 @@ def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3
     )
     assert response.status_code == http.HTTPStatus.OK
 
-    def mock_typeerror():
-        raise TypeError
-
-    def mock_databaseerror():
-        raise DatabaseError
-
-    def mock_deletionerror():
-        raise DeletionError()
-
-    def mock_bucketnotfounderror():
-        raise BucketNotFoundError()
-
     for func in [mock_typeerror, mock_databaseerror, mock_deletionerror, mock_bucketnotfounderror]:
         with unittest.mock.patch("dds_web.api.project.ProjectStatus.delete_project_info", func):
             # Release project
@@ -1593,6 +1700,7 @@ def test_projectstatus_post_deletion_and_archivation_errors(module_client, boto3
             )
             assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
             assert "Server Error: Status was not updated" in response.json["message"]
+            assert project.is_active
 
 
 # GetPublic

--- a/tests/tests_v3/api/test_project.py
+++ b/tests/tests_v3/api/test_project.py
@@ -116,23 +116,30 @@ def test_project(module_client):
 def mock_sqlalchemyerror(_=None):
     raise sqlalchemy.exc.SQLAlchemyError()
 
+
 def mock_typeerror(_=None):
     raise TypeError
+
 
 def mock_databaseerror(_=None):
     raise DatabaseError
 
+
 def mock_deletionerror(_=None):
     raise DeletionError()
+
 
 def mock_bucketnotfounderror(_=None):
     raise BucketNotFoundError()
 
+
 def mock_operationalerror(_=None):
     raise sqlalchemy.exc.OperationalError
 
+
 def mock_attributeerror():
     raise AttributeError
+
 
 # ProjectStatus
 
@@ -573,6 +580,7 @@ def test_projectstatus_archived_project_db_fail(
     )
 
     assert project.is_active
+
 
 def test_projectstatus_aborted_project(module_client, boto3_session):
     """Create a project and try to abort it"""
@@ -1582,6 +1590,7 @@ def test_projectstatus_failed_delete_project_content(module_client, boto3_sessio
             assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
             assert "Server Error: Status was not updated" in response.json["message"]
             assert project.is_active
+
 
 def test_projectstatus_failed_rm_project_user_keys(module_client, boto3_session):
     """Mock the different expections that can occur when deleting project."""


### PR DESCRIPTION
## Read this before submitting the PR

1. Always create a Draft PR first
2. Go through sections 1-5 below, fill them in and check all the boxes
3. Make sure that the branch is updated; if there's an "Update branch" button at the bottom of the PR, rebase or update branch.
4. When all boxes are checked, information is filled in, and the branch is updated: mark as Ready For Review and tag reviewers (top right)
5. Once there is a submitted review, implement the suggestions (if reasonable, otherwise discuss) and request an new review.

If there is a field which you are unsure about, enter the edit mode of this description or go to the [PR template](../.github/pull_request_template.md); There are invisible comments providing descriptions which may be of help.

## 1. Description / Summary

**Add a summary here**: These changes should address the issue of failed project content deletion but project being marked as  inactive. 
The `is_active = False` transaction should be rolled back if an exception gets thrown even if that line is before the try-catch; the only possible scenarion for not being rolled back is when the exception gets thrown by the S3 related code but `db.session.rollback()` fails due to DB issue happening exactly at that time.

## 2. Jira task / GitHub issue

**Is this from a Jira task?** --> HMS-2391

## 3. Type of change - Add label

**What _type of change(s)_ does the PR contain? For an explanation of the different options below, enter edit mode of this PR description template.**

_If you do not want this change to be included in release notes, add the label `skip-changelog`._

- New feature
  - Breaking --> label: `breaking` <!-- If the changes in this PR will cause existing functionality to not work as expected. E.g. with the master branch of the `dds_cli`. Add info here on how the change is breaking. -->
  - Non-breaking --> label: `feature` <!-- If the changes will not cause existing functionality to fail. "Non-breaking" is just an addition of a new feature. -->
- Database change --> label: `feature` or none at all.
  _Remember the to include a new migration version, **or** explain here why it's not needed._ <!-- If you've changed something in `models.py`. For a guide on how to add the a new migration version, look at the "Database changes" section in the README.md. -->
- Bug fix --> label: `bug` <!-- If a bug is fixed in existing functionality. If the bug fix also is a breaking change (see above), add info about that beside this check box. -->
- Security Alert fix <!-- If the PR attempts to solve a security vulnerability, e.g. reported by the "Security" tab in the repo. -->
  - Package update --> label: `dependency` <!-- If the Security alert fix consists of updating a package / dependency version -->
    - Major version update <!-- If the package / dependency version update is a major upgrade, e.g. 1.0.0 to 2.0.0 -->
- Documentation --> label can be skipped, will be included in "other changes" <!-- If the PR adds or updates documentation such as e.g. Technical Overview or a architecture decision (dds_web/doc/architecture/decisions.) -->
- Workflow --> label: `skip-changelog` <!-- If the PR includes a change in e.g. the github actions files (dds_web/.github/*) or another type of workflow change. Anything that alters our or the codes workflow. -->
- Tests **only** --> label: `skip-changelog` <!-- If the PR only contains tests, none of the other types of changes listed above. -->

## 4. Additional information

- [x] I have added an entry to the [Sprintlog](../SPRINTLOG.md) <!-- Add a row at the bottom of the SPRINTLOG.md file (not needed if PR contains only tests). Follow the format of previous rows. If the PR is the first in a new sprint, add a new sprint header row (follow the format of previous sprints). -->
- [ ] This is a PR to the `master` branch: _If checked, read [the release instructions](../doc/procedures/new_release.md)_ <!-- Check this if the PR is made to the `master` branch. Only the `dev` branch should be doing this. -->
  - [ ] I have followed steps 1-8. <!-- Should be checked if the "PR to `master` branch" box is checked AND the specified steps in the release instructions have been followed. -->

## 5. Actions / Scans

**Make sure that the following checks/actions have passed.**

- **Black**
<!--
  What: Python code formatter.
  How to fix: Run `black .` locally to execute formatting.
-->
- **Prettier**
<!--
  What: General code formatter. Our use case: MD and yaml mainly.
  How to fix: Run npx prettier --write . locally to execute formatting.
-->
- **Yamllint**
<!--
  What: Linting of yaml files.
  How to fix: Manually fix any errors locally.
-->
- **Tests**
<!--
  What: Pytest to verify that functionality works as expected.
  How to fix: Manually fix any errors locally. Follow the instructions in the "Run tests" section of the README.md to run the tests locally.
  Additional info: The PR should ALWAYS include new tests or fixed tests when there are code changes. When pytest action has finished, it will post a codecov report; Look at this report and verify the files you have changed are listed. "90% <100.00%> (+0.8%)" means "Tests cover 90% of the changed file, <100 % of this PR's code changes are tested>, and (the code changes and added tests increased the overall test coverage with 0.8%)
-->
- **CodeQL**
<!--
  What: Scan for security vulnerabilities, bugs, errors.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- **Trivy**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->
- **Snyk**
<!--
  What: Security scanner.
  How to fix: Go through the alerts and either manually fix, dismiss or ignore. Add info on ignored or dismissed alerts.
-->

If an action does not pass and you need help with how to solve it, enter edit mode of this PR template or go to the [PR template](../.github/pull_request_template.md).
