### PR TITLE
Hms 2656 handle failed mail send

### DIFF
--- a/.github/workflows/publish_and_trivyscan.yml
+++ b/.github/workflows/publish_and_trivyscan.yml
@@ -27,13 +27,31 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+      # pandoc/latex pinned by digest:
+      #
+      # We deliberately pin to the immutable digest of pandoc/latex:latest
+      # (TeX Live 2026, default repo https://mirror.ctan.org/systems/texlive/tlnet)
+      # rather than a minor-version tag. The minor-version tags (:3.6, :3.7, ...)
+      # bundle the TL release that was current at image build time, and once that
+      # TL year is frozen by the next release the image's tlmgr default repo
+      # silently switches to ftp://tug.org/historic/.../tlnet-final, which is
+      # unreachable from GitHub-hosted runners (FTP). Pinning to the digest of
+      # a recently-rebuilt :latest gives us reproducibility AND a working live
+      # tlnet mirror. Bump the digest deliberately when you want to roll forward.
+      #
+      # set -eo pipefail makes silent tlmgr install failures fail the step.
+      # kpsewhich lato.sty verifies the install actually succeeded before we
+      # hand off to pandoc, so a future regression surfaces here with a clear
+      # error instead of as a downstream LaTeX "File `lato.sty' not found".
       - name: Build tech overview PDF
-        uses: docker://pandoc/latex:3.2
+        uses: docker://pandoc/latex@sha256:467bb9a70723627a34eb7003e46a1bb7c9344ea4580a46c4c978860784a6a754
         with:
           entrypoint: /bin/sh
           args: >-
             -c "
+            set -eo pipefail &&
             tlmgr install cm-super fontaxes lato pdflscape xkeyval &&
+            kpsewhich lato.sty &&
             updmap-sys &&
             pandoc
             --output=dds_web/static/dds-technical-overview.pdf
@@ -50,13 +68,18 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+      # See the comment on the build_tech_overview job for why this image is
+      # pinned by digest rather than by minor version, and why the script uses
+      # set -eo pipefail + kpsewhich.
       - name: Build troubleshooting guide
-        uses: docker://pandoc/latex:3.2
+        uses: docker://pandoc/latex@sha256:467bb9a70723627a34eb7003e46a1bb7c9344ea4580a46c4c978860784a6a754
         with:
           entrypoint: /bin/sh
           args: >-
             -c "
+            set -eo pipefail &&
             tlmgr install cm-super fontaxes lato xkeyval &&
+            kpsewhich lato.sty &&
             updmap-sys &&
             pandoc
             --output=dds_web/static/dds-troubleshooting.pdf

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -623,3 +623,7 @@ _Nothing merged during this sprint_
 - Bump pillow from 12.1.1 to 12.2.0 ([#1830]https://github.com/ScilifelabDataCentre/dds_web/pull/1830)
 - Bump minimatch and serve in /dds_web/static ([#1831]https://github.com/ScilifelabDataCentre/dds_web/pull/1831)
 - Fix broken action ([#1832]https://github.com/ScilifelabDataCentre/dds_web/pull/1832)
+
+## 2026-04-27 - 2026-05-08
+
+- Fail gracefully when HOTP email cannot be sent ([#1834]https://github.com/ScilifelabDataCentre/dds_web/pull/1834)

--- a/dds_web/errors.py
+++ b/dds_web/errors.py
@@ -115,6 +115,28 @@ class KeyOperationError(LoggedHTTPException):
         general_logger.warning(message)
 
 
+class TwoFactorEmailError(LoggedHTTPException):
+    """Errors raised when the one-time-code email cannot be sent.
+
+    Used to convert transient SMTP / DNS / socket failures during HOTP
+    email delivery into a controlled 503 response, instead of letting
+    the exception propagate as a generic 500.
+    """
+
+    code = http.HTTPStatus.SERVICE_UNAVAILABLE
+
+    def __init__(
+        self,
+        message=(
+            "We could not send your one-time code right now. "
+            "Please try again in a moment."
+        ),
+    ):
+        super().__init__(message)
+
+        general_logger.warning(message)
+
+
 class AuthenticationError(LoggedHTTPException):
     """Base class for errors due to authentication failure."""
 

--- a/dds_web/errors.py
+++ b/dds_web/errors.py
@@ -128,8 +128,7 @@ class TwoFactorEmailError(LoggedHTTPException):
     def __init__(
         self,
         message=(
-            "We could not send your one-time code right now. "
-            "Please try again in a moment."
+            "We could not send your one-time code right now. " "Please try again in a moment."
         ),
     ):
         super().__init__(message)

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -6,6 +6,8 @@
 
 # built in libraries
 import gc
+import smtplib
+import socket
 
 # Installed
 import datetime
@@ -23,6 +25,7 @@ from dds_web.errors import (
     AccessDeniedError,
     InviteError,
     TokenMissingError,
+    TwoFactorEmailError,
 )
 from dds_web.database import models
 import dds_web.utils
@@ -327,7 +330,16 @@ def __handle_multi_factor_authentication(user, mfa_auth_time_string):
 
 
 def send_hotp_email(user):
-    """Send one time code via email."""
+    """Send one time code via email.
+
+    Raises:
+        TwoFactorEmailError: If the SMTP / DNS / socket layer fails
+            while sending the email. Callers should treat this as a
+            transient failure and surface it as a 503 to the client
+            (or render an equivalent message in the web UI). It is
+            intentionally distinct from "no email needed to be sent"
+            (the cooldown / activation case), which still returns False.
+    """
     # Only send if
     # - not trying to activate hotp
     # or
@@ -344,7 +356,21 @@ def send_hotp_email(user):
 
         # Create and send email
         msg = dds_web.utils.create_one_time_password_email(user=user, hotp_value=hotp_value)
-        mail.send(msg)
+        try:
+            mail.send(msg)
+        except (smtplib.SMTPException, socket.gaierror, TimeoutError, OSError) as exc:
+            # Preserve the traceback for ops while keeping the user-facing
+            # response controlled. We log via the app logger (full traceback)
+            # and emit a structured action event so this can be alerted on.
+            flask.current_app.logger.exception(
+                "Failed to send HOTP email to user '%s'", user.username
+            )
+            action_logger.warning(
+                "hotp_email_send_failed",
+                user=user.username,
+                reason=type(exc).__name__,
+            )
+            raise TwoFactorEmailError() from exc
         return True
     return False
 

--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -407,9 +407,7 @@ def login():
                     flask.flash("One-Time Code has been sent to your primary email.")
             except ddserr.TwoFactorEmailError as exc:
                 flask.flash(exc.description or str(exc), "danger")
-                return flask.redirect(
-                    flask.url_for("auth_blueprint.login", next=next_target)
-                )
+                return flask.redirect(flask.url_for("auth_blueprint.login", next=next_target))
 
         # Generate signed token that indicates that the user has authenticated
         token_2fa_initiated = dds_web.security.tokens.jwt_token(

--- a/dds_web/web/user.py
+++ b/dds_web/web/user.py
@@ -397,9 +397,19 @@ def login():
 
         # Correct credentials still needs 2fa
         if not user.totp_enabled:
-            # Send 2fa token to user's email
-            if dds_web.security.auth.send_hotp_email(user):
-                flask.flash("One-Time Code has been sent to your primary email.")
+            # Send 2fa token to user's email. If the SMTP / DNS layer
+            # is having a transient hiccup we don't want to land the
+            # user on the "enter your code" page with no code en route,
+            # nor crash with a 500: flash a friendly message and keep
+            # them on /login so they can retry.
+            try:
+                if dds_web.security.auth.send_hotp_email(user):
+                    flask.flash("One-Time Code has been sent to your primary email.")
+            except ddserr.TwoFactorEmailError as exc:
+                flask.flash(exc.description or str(exc), "danger")
+                return flask.redirect(
+                    flask.url_for("auth_blueprint.login", next=next_target)
+                )
 
         # Generate signed token that indicates that the user has authenticated
         token_2fa_initiated = dds_web.security.tokens.jwt_token(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -84,9 +84,7 @@ def _fresh_user_for_hotp() -> models.User:
         OSError("connection reset by peer"),
     ],
 )
-def test_send_hotp_email_raises_TwoFactorEmailError_on_mail_failure(
-    request_ctx_for_login, exc
-):
+def test_send_hotp_email_raises_TwoFactorEmailError_on_mail_failure(request_ctx_for_login, exc):
     """Each of the documented failure modes must surface as TwoFactorEmailError."""
     user = _fresh_user_for_hotp()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,17 @@
+import socket
+import smtplib
+import unittest.mock
+
+import flask
+import flask_mail
+import pytest
+
 import tests
 import http
 from dds_web.database import models
 from dds_web import db
+from dds_web.errors import TwoFactorEmailError
+from dds_web.security.auth import send_hotp_email
 
 
 # verify_token
@@ -36,3 +46,78 @@ def test_verify_token_user_not_exists_after_deletion(client):
     response_json = response.json
     message = response_json.get("message")
     assert message == "Invalid token. Try reauthenticating."
+
+
+# send_hotp_email -- unit tests for the mail-failure handling ###############
+#
+# send_hotp_email must convert transient mail-send failures (SMTP / DNS /
+# socket layer) into a TwoFactorEmailError. We need an active request
+# context because the function inspects flask.request.path.
+
+
+@pytest.fixture
+def request_ctx_for_login(client):
+    """Push a request context that looks like a /login POST.
+
+    send_hotp_email branches on flask.request.path and skips sending if the
+    path ends in /user/hotp/activate, so we use /login here.
+    """
+    app = flask.current_app or client.application
+    with app.test_request_context("/login", method="POST"):
+        yield
+
+
+def _fresh_user_for_hotp() -> models.User:
+    """Return a user whose hotp cooldown has expired so a send is attempted."""
+    user = models.User.query.get("researchuser")
+    user.hotp_issue_time = None
+    db.session.commit()
+    return user
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        socket.gaierror(-3, "Try again"),
+        smtplib.SMTPException("relay rejected"),
+        TimeoutError("smtp connect timeout"),
+        OSError("connection reset by peer"),
+    ],
+)
+def test_send_hotp_email_raises_TwoFactorEmailError_on_mail_failure(
+    request_ctx_for_login, exc
+):
+    """Each of the documented failure modes must surface as TwoFactorEmailError."""
+    user = _fresh_user_for_hotp()
+
+    with unittest.mock.patch.object(flask_mail.Mail, "send", side_effect=exc):
+        with pytest.raises(TwoFactorEmailError):
+            send_hotp_email(user)
+
+
+def test_send_hotp_email_does_not_raise_on_cooldown(request_ctx_for_login):
+    """The cooldown / no-send branch must keep returning False, not raise."""
+    user = models.User.query.get("researchuser")
+    # Pretend a HOTP was just issued -- send_hotp_email should not call mail.send.
+    import datetime
+    import dds_web.utils
+
+    user.hotp_issue_time = dds_web.utils.current_time()
+    db.session.commit()
+
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+        result = send_hotp_email(user)
+        assert mock_mail_send.call_count == 0
+
+    assert result is False
+
+
+def test_send_hotp_email_returns_True_on_successful_send(request_ctx_for_login):
+    """Happy-path regression: a successful mail.send returns True."""
+    user = _fresh_user_for_hotp()
+
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+        result = send_hotp_email(user)
+        assert mock_mail_send.call_count == 1
+
+    assert result is True

--- a/tests/test_basic_api.py
+++ b/tests/test_basic_api.py
@@ -106,6 +106,48 @@ def test_auth_correct_credentials(client):
         assert mock_mail_send.call_count == 0
 
 
+def test_encrypted_token_returns_503_when_mail_dns_fails(client):
+    """If sending the HOTP email fails (DNS / SMTP / socket layer), the
+    /user/encrypted_token endpoint must return 503 with a clear message,
+    not 500. Mirrors the behavior of the web /login redirect-with-flash
+    fix on the API side.
+    """
+    import socket as _socket
+
+    with unittest.mock.patch.object(
+        flask_mail.Mail,
+        "send",
+        side_effect=_socket.gaierror(-3, "Try again"),
+    ) as mock_mail_send:
+        response = client.get(
+            tests.DDSEndpoint.ENCRYPTED_TOKEN,
+            auth=("researchuser", "password"),
+            headers=tests.DEFAULT_HEADER,
+        )
+        assert mock_mail_send.call_count == 1
+
+    assert response.status_code == http.HTTPStatus.SERVICE_UNAVAILABLE
+    assert "one-time code" in (response.json or {}).get("message", "").lower()
+
+
+def test_encrypted_token_returns_503_when_smtp_fails(client):
+    """smtplib.SMTPException is also caught and surfaced as 503."""
+    import smtplib as _smtplib
+
+    with unittest.mock.patch.object(
+        flask_mail.Mail,
+        "send",
+        side_effect=_smtplib.SMTPException("relay rejected"),
+    ):
+        response = client.get(
+            tests.DDSEndpoint.ENCRYPTED_TOKEN,
+            auth=("researchuser", "password"),
+            headers=tests.DEFAULT_HEADER,
+        )
+
+    assert response.status_code == http.HTTPStatus.SERVICE_UNAVAILABLE
+
+
 # Second Factor ################################################################### Second Factor #
 
 

--- a/tests/test_login_web.py
+++ b/tests/test_login_web.py
@@ -201,9 +201,7 @@ def test_password_reset(client: flask.testing.FlaskClient):
 # We exercise the three failure modes that send_hotp_email now catches.
 
 
-def _post_login_with_failing_mail(
-    client: flask.testing.FlaskClient, side_effect: Exception
-):
+def _post_login_with_failing_mail(client: flask.testing.FlaskClient, side_effect: Exception):
     """Helper: post valid credentials to /login while mail.send raises side_effect."""
     user_auth = UserAuth(USER_CREDENTIALS["researcher"])
 
@@ -250,9 +248,7 @@ def _assert_redirected_back_to_login(client, response):
 
 def test_login_redirects_back_when_mail_dns_fails(client):
     """socket.gaierror (DNS lookup failure) on mail.send must not 500."""
-    response = _post_login_with_failing_mail(
-        client, side_effect=socket.gaierror(-3, "Try again")
-    )
+    response = _post_login_with_failing_mail(client, side_effect=socket.gaierror(-3, "Try again"))
     _assert_redirected_back_to_login(client, response)
 
 

--- a/tests/test_login_web.py
+++ b/tests/test_login_web.py
@@ -1,5 +1,10 @@
 import datetime
+import socket
+import smtplib
+import unittest.mock
+
 import flask
+import flask_mail
 from http import HTTPStatus
 import werkzeug
 from typing import Dict
@@ -183,3 +188,85 @@ def test_password_reset(client: flask.testing.FlaskClient):
         response.json.get("message")
         == "Password reset performed after last authentication. Start a new authenticated session to proceed."
     )
+
+
+# Web /login resilience when the HOTP email cannot be sent ###################
+#
+# When mail.send fails (e.g. transient SMTP / DNS hiccup), the /login POST
+# handler must:
+#   - not return 500
+#   - not advance the user to the /confirm_2fa page
+#   - not put a 2fa_initiated_token in the session
+#   - flash a user-facing message
+# We exercise the three failure modes that send_hotp_email now catches.
+
+
+def _post_login_with_failing_mail(
+    client: flask.testing.FlaskClient, side_effect: Exception
+):
+    """Helper: post valid credentials to /login while mail.send raises side_effect."""
+    user_auth = UserAuth(USER_CREDENTIALS["researcher"])
+
+    # Prime CSRF token
+    response = client.get(DDSEndpoint.LOGIN, headers=DEFAULT_HEADER)
+    assert response.status_code == HTTPStatus.OK
+    form_token: str = flask.g.csrf_token
+
+    form_data: Dict = {
+        "csrf_token": form_token,
+        "username": user_auth.as_tuple()[0],
+        "password": user_auth.as_tuple()[1],
+        "submit": "Login",
+    }
+
+    with unittest.mock.patch.object(
+        flask_mail.Mail, "send", side_effect=side_effect
+    ) as mock_mail_send:
+        response = client.post(
+            DDSEndpoint.LOGIN,
+            json=form_data,
+            follow_redirects=True,
+            headers=DEFAULT_HEADER,
+        )
+        assert mock_mail_send.call_count == 1
+
+    return response
+
+
+def _assert_redirected_back_to_login(client, response):
+    """Common assertions for the failure path."""
+    # Followed redirects -- final page is /login again, not /confirm_2fa.
+    assert response.status_code == HTTPStatus.OK
+    assert response.request.path == DDSEndpoint.LOGIN
+
+    # No 2fa token leaked into the session -- the user has no code anyway.
+    with client.session_transaction() as session:
+        assert "2fa_initiated_token" not in session
+
+    # The flashed message is rendered into the page; assert the user sees it.
+    body = response.data.decode("utf-8", errors="replace")
+    assert "could not send your one-time code" in body.lower()
+
+
+def test_login_redirects_back_when_mail_dns_fails(client):
+    """socket.gaierror (DNS lookup failure) on mail.send must not 500."""
+    response = _post_login_with_failing_mail(
+        client, side_effect=socket.gaierror(-3, "Try again")
+    )
+    _assert_redirected_back_to_login(client, response)
+
+
+def test_login_redirects_back_when_smtp_fails(client):
+    """smtplib.SMTPException must not 500."""
+    response = _post_login_with_failing_mail(
+        client, side_effect=smtplib.SMTPException("relay rejected message")
+    )
+    _assert_redirected_back_to_login(client, response)
+
+
+def test_login_redirects_back_when_socket_oserror(client):
+    """Generic OSError (e.g. connection reset) must not 500."""
+    response = _post_login_with_failing_mail(
+        client, side_effect=OSError("connection reset by peer")
+    )
+    _assert_redirected_back_to_login(client, response)


### PR DESCRIPTION
## Pull Request Template

### Before Marking as Ready for Review

- [x] Add relevant information to the sections below ([Summary](#summary) etc)
- [x] Rebase or merge the latest `dev` (or other targeted branch)
- [ ] Update documentation if needed
- [x] Add an entry to the [`SPRINTLOG.md`](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/SPRINTLOG.md) if needed
- [x] Choose an appropriate label. See [here](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/labelling_a_pull_request.md) for information on the labelling options
- [x] The code follows the [style guidelines](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/style_guidelines.md)
- [x] Perform a self-review: read the diff as if reviewing someone else's code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] Verify that all checks and tests have passed

**If the target branch is `master`**:

- [ ] Read and follow [the release instructions](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/new_release.md)

### Summary

A single transient SMTP/DNS failure when sending the HOTP one-time code currently produces an HTTP 500 with a stack trace. We want this class of failure to become a controlled, user-visible response that does not advance the auth state machine into a dead end (e.g., the web flow shouldn't drop the user on the "enter your code" page when no code was ever sent).
The fix has to cover all three call sites of send_hotp_email, not just the one in the log. They are:
dds_web/web/user.py:401 — web /login POST. Browser flow.
dds_web/security/auth.py:421 — @basic_auth.verify_password callback. Hit by POST /api/v1/user/encrypted_token (CLI initial login).
dds_web/security/auth.py:320 — __handle_multi_factor_authentication, hit when an API token's mfa_auth_time has expired.

### Related Issue/Ticket

https://scilifelab.atlassian.net/browse/HMS-2656

### Testing

_If applicable: How did you verify the change? Include commands, data, or screenshots._

### Reviewer Notes

_Anything that helps reviewers (e.g. areas needing close attention)._

---

Once all boxes are checked, mark the PR as **Ready for Review** and tag at least one team member as the initial reviewer.
