### PR TITLE
Correct the troubleshooting guide regarding TOTP reset/deactivation

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -630,3 +630,4 @@ _Nothing merged during this sprint_
 - Update dependency cryptography to v46.0.7 [SECURITY] ([#1824]https://github.com/ScilifelabDataCentre/dds_web/pull/1824)
 - Update dependency postcss to v8.5.10 [SECURITY] ([#1833]https://github.com/ScilifelabDataCentre/dds_web/pull/1833)
 - Update dependency Mako to v1.3.11 [SECURITY] ([#1828]https://github.com/ScilifelabDataCentre/dds_web/pull/1828)
+- Correct the troubleshooting guide regarding TOTP reset/deactivation ([#1835]https://github.com/ScilifelabDataCentre/dds_web/pull/1835)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -196,10 +196,8 @@ lost access to it (e.g. due to a broken or lost device), the Data Centre can dea
 let you authenticate using the default email option. After this you can choose to activate the authenticator app method
 again.
 
-- Researcher role: Please contact a SciLifeLab unit responsible for one of your ongoing delivery projects and tell them
-  you need a reset of the 2FA method.
-- Unit Admin / Personnel: Please contact Data Centre and ask for a reset of the 2FA method. Inform them of the username
-  and email address of the affected account.
+Please contact Data Centre and ask for a reset of the 2FA method; complenent the request with the username
+and email address of the affected account.
 
 ## R. Windows: DDS freezes after message
 


### PR DESCRIPTION
## Pull Request Template

### Before Marking as Ready for Review

- [ ] Add relevant information to the sections below ([Summary](#summary) etc)
- [ ] Rebase or merge the latest `dev` (or other targeted branch)
- [ ] Update documentation if needed
- [ ] Add an entry to the [`SPRINTLOG.md`](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/SPRINTLOG.md) if needed
- [ ] Choose an appropriate label. See [here](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/labelling_a_pull_request.md) for information on the labelling options
- [ ] The code follows the [style guidelines](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/style_guidelines.md)
- [ ] Perform a self-review: read the diff as if reviewing someone else's code
- [ ] I have commented the code, particularly in hard-to-understand areas
- [ ] Verify that all checks and tests have passed

**If the target branch is `master`**:

- [ ] Read and follow [the release instructions](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/new_release.md)

### Summary

The Troubleshooting guide wrongly states that Researcher roles should contact the Units' support for 2FA reset, which in reality this functionality is limited to Super Admins.
https://scilifelab.slack.com/archives/C08G6FH7LQM/p1776245013602299

### Related Issue/Ticket

[HMS-2654](https://scilifelab.atlassian.net/jira/software/projects/HMS/boards/13?selectedIssue=HMS-2654)

### Testing

_If applicable: How did you verify the change? Include commands, data, or screenshots._

### Reviewer Notes

_Anything that helps reviewers (e.g. areas needing close attention)._

---

Once all boxes are checked, mark the PR as **Ready for Review** and tag at least one team member as the initial reviewer.


[HMS-2654]: https://scilifelab.atlassian.net/browse/HMS-2654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ