### PR TITLE
Fix(auth): roll back HOTP state when one-time-code email send fails

### DIFF
--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -634,3 +634,4 @@ _Nothing merged during this sprint_
 - Update dependency Authlib to v1.6.11 [SECURITY] ([#1827]https://github.com/ScilifelabDataCentre/dds_web/pull/1827)
 - Update dependency pytest to v9 [SECURITY] ([#1826]https://github.com/ScilifelabDataCentre/dds_web/pull/1826)
 - New version v2.14.3 ([#1837]https://github.com/ScilifelabDataCentre/dds_web/pull/1837)
+- Fix(auth): roll back HOTP state when one-time-code email send fails ([#1838]https://github.com/ScilifelabDataCentre/dds_web/pull/1838)

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -16,10 +16,11 @@ import flask
 import json
 import jwcrypto
 from jwcrypto import jwk, jwt
+import sqlalchemy
 import structlog
 
 # Own modules
-from dds_web import basic_auth, auth, mail
+from dds_web import basic_auth, auth, mail, db
 from dds_web.errors import (
     AuthenticationError,
     AccessDeniedError,
@@ -359,6 +360,29 @@ def send_hotp_email(user):
         try:
             mail.send(msg)
         except (smtplib.SMTPException, socket.gaierror, TimeoutError, OSError) as exc:
+            # generate_HOTP_token() above committed `hotp_counter += 1` and
+            # `hotp_issue_time = now` to the user row. If we leave that state
+            # in place, an immediate retry will hit the 15-minute cooldown
+            # branch in this function (see the `elif` above), no email will
+            # be sent, and the user will be redirected to the code-entry page
+            # with no code en route. Roll the state back so a retry can issue
+            # a fresh code. We bump the counter further (via reset_current_HOTP)
+            # so the just-generated code is invalidated even if it somehow
+            # ends up delivered late.
+            try:
+                user.reset_current_HOTP()
+                db.session.commit()
+            except sqlalchemy.exc.SQLAlchemyError:
+                # If the rollback commit itself fails, surface the original
+                # mail-send failure to the user rather than a confusing DB
+                # error. The cooldown will simply persist; the user will be
+                # locked out until it expires, which is no worse than today.
+                db.session.rollback()
+                flask.current_app.logger.exception(
+                    "Failed to roll back HOTP state for user '%s' after mail send failure",
+                    user.username,
+                )
+
             # Preserve the traceback for ops while keeping the user-facing
             # response controlled. We log via the app logger (full traceback)
             # and emit a structured action event so this can be alerted on.

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -372,7 +372,7 @@ def send_hotp_email(user):
             try:
                 user.reset_current_HOTP()
                 db.session.commit()
-            except sqlalchemy.exc.SQLAlchemyError:
+            except sqlalchemy.exc.SQLAlchemyError as rollback_exc:
                 # If the rollback commit itself fails, surface the original
                 # mail-send failure to the user rather than a confusing DB
                 # error. The cooldown will simply persist; the user will be
@@ -385,6 +385,7 @@ def send_hotp_email(user):
                 action_logger.error(
                     "hotp_state_rollback_failed",
                     user=user.username,
+                    reason=type(rollback_exc).__name__,
                 )
 
             # Preserve the traceback for ops while keeping the user-facing

--- a/dds_web/security/auth.py
+++ b/dds_web/security/auth.py
@@ -382,6 +382,10 @@ def send_hotp_email(user):
                     "Failed to roll back HOTP state for user '%s' after mail send failure",
                     user.username,
                 )
+                action_logger.error(
+                    "hotp_state_rollback_failed",
+                    user=user.username,
+                )
 
             # Preserve the traceback for ops while keeping the user-facing
             # response controlled. We log via the app logger (full traceback)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -119,3 +119,58 @@ def test_send_hotp_email_returns_True_on_successful_send(request_ctx_for_login):
         assert mock_mail_send.call_count == 1
 
     assert result is True
+
+
+def test_send_hotp_email_resets_hotp_state_on_mail_failure(request_ctx_for_login):
+    """Regression: a transient mail-send failure must roll back the HOTP state.
+
+    generate_HOTP_token() commits hotp_issue_time = now and bumps hotp_counter
+    BEFORE mail.send is attempted. If we left that committed state in place
+    when mail.send fails, the next call to send_hotp_email within 15 minutes
+    would silently hit the cooldown branch and return False without sending
+    another email -- locking the user out for the cooldown window despite
+    the UI telling them to retry.
+
+    After a failure, hotp_issue_time must be None so a retry takes the
+    email-sending branch again.
+    """
+    user = _fresh_user_for_hotp()
+    counter_before = user.hotp_counter
+
+    with unittest.mock.patch.object(
+        flask_mail.Mail, "send", side_effect=socket.gaierror(-3, "Try again")
+    ):
+        with pytest.raises(TwoFactorEmailError):
+            send_hotp_email(user)
+
+    db.session.refresh(user)
+    assert user.hotp_issue_time is None, (
+        "hotp_issue_time should be reset so retry is not silenced by cooldown"
+    )
+    # reset_current_HOTP() bumps the counter on top of generate_HOTP_token()'s
+    # bump, invalidating the just-generated code in case of late delivery.
+    assert user.hotp_counter > counter_before
+
+
+def test_send_hotp_email_retry_after_failure_actually_sends(request_ctx_for_login):
+    """Regression: a retry within the cooldown window after a failed send
+    must actually call mail.send again, not be silenced by the cooldown."""
+    user = _fresh_user_for_hotp()
+
+    # First attempt: mail.send fails -> TwoFactorEmailError, state rolled back.
+    with unittest.mock.patch.object(
+        flask_mail.Mail, "send", side_effect=socket.gaierror(-3, "Try again")
+    ):
+        with pytest.raises(TwoFactorEmailError):
+            send_hotp_email(user)
+
+    db.session.refresh(user)
+
+    # Immediate retry (well under 15 minutes): mail.send must be called again.
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
+        result = send_hotp_email(user)
+        assert mock_mail_send.call_count == 1, (
+            "Retry after mail failure must reach mail.send, not be silenced by cooldown"
+        )
+
+    assert result is True

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -144,9 +144,9 @@ def test_send_hotp_email_resets_hotp_state_on_mail_failure(request_ctx_for_login
             send_hotp_email(user)
 
     db.session.refresh(user)
-    assert user.hotp_issue_time is None, (
-        "hotp_issue_time should be reset so retry is not silenced by cooldown"
-    )
+    assert (
+        user.hotp_issue_time is None
+    ), "hotp_issue_time should be reset so retry is not silenced by cooldown"
     # reset_current_HOTP() bumps the counter on top of generate_HOTP_token()'s
     # bump, invalidating the just-generated code in case of late delivery.
     assert user.hotp_counter > counter_before
@@ -169,8 +169,8 @@ def test_send_hotp_email_retry_after_failure_actually_sends(request_ctx_for_logi
     # Immediate retry (well under 15 minutes): mail.send must be called again.
     with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_mail_send:
         result = send_hotp_email(user)
-        assert mock_mail_send.call_count == 1, (
-            "Retry after mail failure must reach mail.send, not be silenced by cooldown"
-        )
+        assert (
+            mock_mail_send.call_count == 1
+        ), "Retry after mail failure must reach mail.send, not be silenced by cooldown"
 
     assert result is True

--- a/tests/test_basic_api.py
+++ b/tests/test_basic_api.py
@@ -176,9 +176,9 @@ def test_encrypted_token_retry_after_mail_failure_actually_sends(client):
             auth=("researchuser", "password"),
             headers=tests.DEFAULT_HEADER,
         )
-        assert mock_second.call_count == 1, (
-            "Retry after mail failure must reach mail.send, not be silenced by cooldown"
-        )
+        assert (
+            mock_second.call_count == 1
+        ), "Retry after mail failure must reach mail.send, not be silenced by cooldown"
     assert response_2.status_code == http.HTTPStatus.OK
 
 

--- a/tests/test_basic_api.py
+++ b/tests/test_basic_api.py
@@ -148,6 +148,40 @@ def test_encrypted_token_returns_503_when_smtp_fails(client):
     assert response.status_code == http.HTTPStatus.SERVICE_UNAVAILABLE
 
 
+def test_encrypted_token_retry_after_mail_failure_actually_sends(client):
+    """Regression: a failed mail.send on /user/encrypted_token must roll back
+    the HOTP state so that an immediate retry reaches mail.send again, instead
+    of being silenced by the 15-minute cooldown branch in send_hotp_email.
+    """
+    import socket as _socket
+
+    # First call: mail.send fails -> 503, HOTP state must be rolled back.
+    with unittest.mock.patch.object(
+        flask_mail.Mail,
+        "send",
+        side_effect=_socket.gaierror(-3, "Try again"),
+    ) as mock_first:
+        response_1 = client.get(
+            tests.DDSEndpoint.ENCRYPTED_TOKEN,
+            auth=("researchuser", "password"),
+            headers=tests.DEFAULT_HEADER,
+        )
+        assert mock_first.call_count == 1
+    assert response_1.status_code == http.HTTPStatus.SERVICE_UNAVAILABLE
+
+    # Immediate retry: mail.send must be called again (not silenced by cooldown).
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_second:
+        response_2 = client.get(
+            tests.DDSEndpoint.ENCRYPTED_TOKEN,
+            auth=("researchuser", "password"),
+            headers=tests.DEFAULT_HEADER,
+        )
+        assert mock_second.call_count == 1, (
+            "Retry after mail failure must reach mail.send, not be silenced by cooldown"
+        )
+    assert response_2.status_code == http.HTTPStatus.OK
+
+
 # Second Factor ################################################################### Second Factor #
 
 

--- a/tests/test_login_web.py
+++ b/tests/test_login_web.py
@@ -314,9 +314,9 @@ def test_login_retry_after_mail_failure_actually_sends(client):
         response_2 = client.post(
             DDSEndpoint.LOGIN, json=form_data, follow_redirects=True, headers=DEFAULT_HEADER
         )
-        assert mock_second.call_count == 1, (
-            "Retry after a failed send must call mail.send, not hit cooldown"
-        )
+        assert (
+            mock_second.call_count == 1
+        ), "Retry after a failed send must call mail.send, not hit cooldown"
 
     assert response_2.request.path == DDSEndpoint.CONFIRM_2FA
     with client.session_transaction() as session:

--- a/tests/test_login_web.py
+++ b/tests/test_login_web.py
@@ -266,3 +266,58 @@ def test_login_redirects_back_when_socket_oserror(client):
         client, side_effect=OSError("connection reset by peer")
     )
     _assert_redirected_back_to_login(client, response)
+
+
+def test_login_retry_after_mail_failure_actually_sends(client):
+    """Regression: when mail.send fails on a /login POST, the HOTP state must
+    be rolled back so that an immediate second POST actually triggers another
+    mail.send instead of being silenced by the 15-minute cooldown branch.
+
+    Before the rollback fix, generate_HOTP_token() committed
+    hotp_issue_time = now before mail.send was attempted; if mail.send then
+    failed, the state stayed committed and the next attempt entered the
+    cooldown branch (no email, but flow advanced to /confirm_2fa). This test
+    locks in the correct behavior: retry within the cooldown window must
+    reach mail.send again.
+    """
+    user_auth = UserAuth(USER_CREDENTIALS["researcher"])
+
+    # Prime CSRF token + first-attempt failure
+    response = client.get(DDSEndpoint.LOGIN, headers=DEFAULT_HEADER)
+    assert response.status_code == HTTPStatus.OK
+    form_token: str = flask.g.csrf_token
+    form_data: Dict = {
+        "csrf_token": form_token,
+        "username": user_auth.as_tuple()[0],
+        "password": user_auth.as_tuple()[1],
+        "submit": "Login",
+    }
+
+    with unittest.mock.patch.object(
+        flask_mail.Mail, "send", side_effect=socket.gaierror(-3, "Try again")
+    ) as mock_first:
+        response_1 = client.post(
+            DDSEndpoint.LOGIN, json=form_data, follow_redirects=True, headers=DEFAULT_HEADER
+        )
+        assert mock_first.call_count == 1
+    # First attempt: redirected back to /login, no token in session.
+    assert response_1.request.path == DDSEndpoint.LOGIN
+    with client.session_transaction() as session:
+        assert "2fa_initiated_token" not in session
+
+    # Second attempt: mail healthy, should reach mail.send again (not silenced
+    # by cooldown), and the flow should advance to /confirm_2fa.
+    form_token_2: str = flask.g.csrf_token
+    form_data["csrf_token"] = form_token_2
+
+    with unittest.mock.patch.object(flask_mail.Mail, "send") as mock_second:
+        response_2 = client.post(
+            DDSEndpoint.LOGIN, json=form_data, follow_redirects=True, headers=DEFAULT_HEADER
+        )
+        assert mock_second.call_count == 1, (
+            "Retry after a failed send must call mail.send, not hit cooldown"
+        )
+
+    assert response_2.request.path == DDSEndpoint.CONFIRM_2FA
+    with client.session_transaction() as session:
+        assert "2fa_initiated_token" in session


### PR DESCRIPTION
## Pull Request Template

### Before Marking as Ready for Review

- [x] Add relevant information to the sections below ([Summary](#summary) etc)
- [x] Rebase or merge the latest `dev` (or other targeted branch)
- [x] Update documentation if needed
- [x] Add an entry to the [`SPRINTLOG.md`](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/SPRINTLOG.md) if needed
- [x] Choose an appropriate label. See [here](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/labelling_a_pull_request.md) for information on the labelling options
- [x] The code follows the [style guidelines](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/style_guidelines.md)
- [x] Perform a self-review: read the diff as if reviewing someone else's code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] Verify that all checks and tests have passed

**If the target branch is `master`**:

- [ ] Read and follow [the release instructions](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/new_release.md)

### Summary

generate_HOTP_token() commits hotp_counter += 1 and hotp_issue_time = now to the user row before mail.send is attempted. The original SMTP-failure fix surfaced the failure to the user but left that committed state in place, so an immediate retry within 15 minutes hit the cooldown branch in send_hotp_email, no email was sent, and login could still advance to the code-entry page despite the user having no code -- effectively a 15-minute lockout on every transient mail failure.

Reset the HOTP state with reset_current_HOTP() and commit the rollback before raising TwoFactorEmailError, so a retry takes the email-sending branch again. Guard the rollback commit so a DB-level transient does not shadow the original mail-send error.

Adds regression tests at the unit level (test_auth.py), the web /login flow (test_login_web.py), and the API /user/encrypted_token flow (test_basic_api.py). Each test asserts that mail.send is actually invoked on the retry rather than being silenced by the cooldown.

### Related Issue/Ticket

_Link GitHub issue or provide Jira ID._

### Testing

_If applicable: How did you verify the change? Include commands, data, or screenshots._

### Reviewer Notes

_Anything that helps reviewers (e.g. areas needing close attention)._

---

Once all boxes are checked, mark the PR as **Ready for Review** and tag at least one team member as the initial reviewer.
