### PR TITLE
Replace linkspector with lychee to remove Chrome/puppeteer depend…

### DIFF
--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -1,4 +1,4 @@
-# Linkspector: Verify links in MD files
+# Lychee: Verify links in MD files
 ---
 name: Linkspector
 on:
@@ -14,15 +14,13 @@ permissions:
   pull-requests: write
 jobs:
   check-links:
-    name: runner / linkspector
+    name: runner / lychee
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install linkspector
-        run: npm install -g @umbrelladocs/linkspector
-      - name: Run linkspector
-        uses: umbrelladocs/action-linkspector@v1.5.2
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
         with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
-          filter_mode: file
+          args: --verbose --no-progress '**/*.md'
+          fail: true
+          github-token: ${{ secrets.github_token }}

--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -22,5 +22,5 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --verbose --no-progress '**/*.md'
-          fail: true
+          fail: false
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress '**/*.md'
+          args: --verbose --no-progress --scheme https --scheme http --accept 401,403 '**/*.md'
           fail: false
-          github-token: ${{ secrets.github_token }}
+          token: ${{ secrets.github_token }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
    <a href="https://opensource.org/licenses/MIT">
       <img alt="Licence: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg">
    </a>
-   <a href="[https://opensource.org/licenses/MIT](https://github.com/psf/black)">
+   <a href="https://github.com/psf/black">
       <img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg">
    </a>
    <a href="https://prettier.io/">

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -644,3 +644,7 @@ _Nothing merged during this sprint_
 - Update dependency idna to v3.15 [SECURITY] ([#1845]https://github.com/ScilifelabDataCentre/dds_web/pull/1845)
 - Update dependency Authlib to v1.6.12 [SECURITY] ([#1844]https://github.com/ScilifelabDataCentre/dds_web/pull/1844)
 - Update dependency Flask-HTTPAuth to v4.8.1 [SECURITY] ([#1818]https://github.com/ScilifelabDataCentre/dds_web/pull/1818)
+
+## 2026-06-08 - 2026-06-19
+
+- Replace linkspector with lychee to remove Chrome/puppeteer dependency ([#1852]https://github.com/ScilifelabDataCentre/dds_web/pull/1852)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -76,10 +76,8 @@ If you cannot find the email, contact the Data Centre.
 
 ## F. CLI Documentation not accessible
 
-You can download the CLI documentation as a PDF.
-Click [here](https://github.com/ScilifelabDataCentre/dds_cli/releases/latest/download/dds_cli_user_manual.pdf). The
-download should start automatically. Notify the Data Centre that the documentation page is down so that we can look
-into it.
+The CLI documentation is available [here](https://scilifelabdatacentre.github.io/dds_cli/).
+Notify the Data Centre that the documentation page is down so that we can look into it.
 
 ## G. Long error message (traceback)
 
@@ -301,7 +299,7 @@ the email is correct and it’s not an email address connected to the KI spam fi
 
 ## F. CLI Documentation not accessible
 
-1. Notify the users that they can download the CLI documentation as a PDF from [here](https://github.com/ScilifelabDataCentre/dds_cli/releases/latest/download/dds_cli_user_manual.pdf)
+1. Notify the users that the CLI documentation is available [here](https://scilifelabdatacentre.github.io/dds_cli/)
 2. Investigate the issue, including whether it could be infrastructure-related.
 
 ## G. Long error message (traceback)


### PR DESCRIPTION
…ency

## Pull Request Template

### Before Marking as Ready for Review

- [x] Add relevant information to the sections below ([Summary](#summary) etc)
- [x] Rebase or merge the latest `dev` (or other targeted branch)
- [x] Update documentation if needed
- [x] Add an entry to the [`SPRINTLOG.md`](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/SPRINTLOG.md) if needed
- [x] Choose an appropriate label. See [here](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/labelling_a_pull_request.md) for information on the labelling options
- [x] The code follows the [style guidelines](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/style_guidelines.md)
- [x] Perform a self-review: read the diff as if reviewing someone else's code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] Verify that all checks and tests have passed

**If the target branch is `master`**:

- [ ] Read and follow [the release instructions](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/new_release.md)

### Summary

Replace linkspector with lychee for link checking
The umbrelladocs/action-linkspector action uses puppeteer internally, which requires a specific Chrome binary to be present on the GitHub Actions runner. This version is updated independently of the action, causing recurring CI failures whenever the runner image is refreshed. Pinning the action version only delays the problem.
This PR replaces linkspector with [lychee](https://github.com/lycheeverse/lychee), a Rust-based link checker with no browser dependency. It performs the same function — scanning Markdown files for broken URLs — without any Chrome/puppeteer involvement, making the workflow stable across runner updates.

Summary of all changes in this PR:

- .github/workflows/linkspector.yml — replaced linkspector with lychee, fixed input name, scoped to HTTP/S only, added --accept 401,403
- .lycheeignore — excludes the private sysadmin repo
- README.md — fixed malformed black badge href
- docs/troubleshooting.md — replaced dead PDF links with the CLI docs page

### Related Issue/Ticket

_Link GitHub issue or provide Jira ID._

### Testing

_If applicable: How did you verify the change? Include commands, data, or screenshots._

### Reviewer Notes

_Anything that helps reviewers (e.g. areas needing close attention)._

---

Once all boxes are checked, mark the PR as **Ready for Review** and tag at least one team member as the initial reviewer.
