### PR TITLE
Replace pandoc/latex Docker action with apt for PDF builds

### DIFF
--- a/.github/workflows/publish_and_trivyscan.yml
+++ b/.github/workflows/publish_and_trivyscan.yml
@@ -40,6 +40,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
             pandoc \
+            lmodern \
             texlive-latex-extra \
             texlive-fonts-extra \
             texlive-fonts-recommended
@@ -64,6 +65,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
             pandoc \
+            lmodern \
             texlive-latex-extra \
             texlive-fonts-extra \
             texlive-fonts-recommended

--- a/.github/workflows/publish_and_trivyscan.yml
+++ b/.github/workflows/publish_and_trivyscan.yml
@@ -27,36 +27,25 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      # pandoc/latex pinned by digest:
-      #
-      # We deliberately pin to the immutable digest of pandoc/latex:latest
-      # (TeX Live 2026, default repo https://mirror.ctan.org/systems/texlive/tlnet)
-      # rather than a minor-version tag. The minor-version tags (:3.6, :3.7, ...)
-      # bundle the TL release that was current at image build time, and once that
-      # TL year is frozen by the next release the image's tlmgr default repo
-      # silently switches to ftp://tug.org/historic/.../tlnet-final, which is
-      # unreachable from GitHub-hosted runners (FTP). Pinning to the digest of
-      # a recently-rebuilt :latest gives us reproducibility AND a working live
-      # tlnet mirror. Bump the digest deliberately when you want to roll forward.
-      #
-      # set -eo pipefail makes silent tlmgr install failures fail the step.
-      # kpsewhich lato.sty verifies the install actually succeeded before we
-      # hand off to pandoc, so a future regression surfaces here with a clear
-      # error instead of as a downstream LaTeX "File `lato.sty' not found".
+      # We use the ubuntu runner + apt rather than the pandoc/latex Docker action.
+      # The Docker-based approach requires tlmgr to install extra LaTeX packages at
+      # runtime, which depends on a reachable CTAN mirror serving a compatible TeX
+      # Live epoch. This breaks silently when the pinned image ages past the current
+      # TL year (tlmgr switches to ftp://tug.org/historic/, unreachable from GH
+      # runners) and also breaks when using :latest (mirror works but image changes
+      # unpredictably). apt packages are stable, versioned with the Ubuntu LTS, and
+      # require no runtime mirror access.
+      - name: Install pandoc and LaTeX dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            pandoc \
+            texlive-latex-extra \
+            texlive-fonts-extra \
+            texlive-fonts-recommended
       - name: Build tech overview PDF
-        uses: docker://pandoc/latex@sha256:467bb9a70723627a34eb7003e46a1bb7c9344ea4580a46c4c978860784a6a754
-        with:
-          entrypoint: /bin/sh
-          args: >-
-            -c "
-            set -eo pipefail &&
-            tlmgr install cm-super fontaxes lato pdflscape xkeyval &&
-            kpsewhich lato.sty &&
-            updmap-sys &&
-            pandoc
-            --output=dds_web/static/dds-technical-overview.pdf
-            docs/technical-overview.md
-            "
+        run: |
+          pandoc --output=dds_web/static/dds-technical-overview.pdf docs/technical-overview.md
       - name: Upload technical overview PDF
         uses: actions/upload-artifact@v7
         with:
@@ -68,23 +57,19 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      # See the comment on the build_tech_overview job for why this image is
-      # pinned by digest rather than by minor version, and why the script uses
-      # set -eo pipefail + kpsewhich.
+      # See the comment on the build_tech_overview job for why apt is used
+      # rather than the pandoc/latex Docker action.
+      - name: Install pandoc and LaTeX dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            pandoc \
+            texlive-latex-extra \
+            texlive-fonts-extra \
+            texlive-fonts-recommended
       - name: Build troubleshooting guide
-        uses: docker://pandoc/latex@sha256:467bb9a70723627a34eb7003e46a1bb7c9344ea4580a46c4c978860784a6a754
-        with:
-          entrypoint: /bin/sh
-          args: >-
-            -c "
-            set -eo pipefail &&
-            tlmgr install cm-super fontaxes lato xkeyval &&
-            kpsewhich lato.sty &&
-            updmap-sys &&
-            pandoc
-            --output=dds_web/static/dds-troubleshooting.pdf
-            docs/troubleshooting.md
-            "
+        run: |
+          pandoc --output=dds_web/static/dds-troubleshooting.pdf docs/troubleshooting.md
       - name: Upload troubleshooting PDF
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/publish_and_trivyscan.yml
+++ b/.github/workflows/publish_and_trivyscan.yml
@@ -41,6 +41,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pandoc \
             lmodern \
+            librsvg2-bin \
             texlive-latex-extra \
             texlive-fonts-extra \
             texlive-fonts-recommended

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -648,3 +648,7 @@ _Nothing merged during this sprint_
 ## 2026-06-08 - 2026-06-19
 
 - Replace linkspector with lychee to remove Chrome/puppeteer dependency ([#1852]https://github.com/ScilifelabDataCentre/dds_web/pull/1852)
+
+## 2026-06-22 - 2026-07-03
+
+- Replace pandoc/latex Docker action with apt for PDF builds ([#1854]https://github.com/ScilifelabDataCentre/dds_web/pull/1854)


### PR DESCRIPTION
tlmgr install at runtime depends on a reachable CTAN mirror serving a compatible TeX Live epoch. Pinned digests rot when the TL year rolls over; :latest is unstable. Switch to apt (texlive-latex-extra + texlive-fonts-extra) on the ubuntu runner — no mirror dependency, no image pinning.

## Pull Request Template

### Before Marking as Ready for Review

- [x] Add relevant information to the sections below ([Summary](#summary) etc)
- [x] Rebase or merge the latest `dev` (or other targeted branch)
- [ ] Update documentation if needed
- [x] Add an entry to the [`SPRINTLOG.md`](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/SPRINTLOG.md) if needed
- [x] Choose an appropriate label. See [here](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/labelling_a_pull_request.md) for information on the labelling options
- [x] The code follows the [style guidelines](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/style_guidelines.md)
- [x] Perform a self-review: read the diff as if reviewing someone else's code
- [x] I have commented the code, particularly in hard-to-understand areas
- [x] Verify that all checks and tests have passed

**If the target branch is `master`**:

- [ ] Read and follow [the release instructions](https://github.com/ScilifelabDataCentre/dds_web/blob/dev/docs/procedures/new_release.md)

### Summary

The `build_tech_overview` and `build_troubleshooting` CI jobs were failing because they used the `pandoc/latex` Docker action and called `tlmgr install` at runtime to fetch extra LaTeX packages. This has a fundamental reliability problem: `tlmgr` depends on a CTAN mirror serving a compatible TeX Live epoch. When a pinned image digest ages past the current TL year, `tlmgr` silently switches to `ftp://tug.org/historic/`, which is unreachable from GitHub-hosted runners. Using `:latest` avoids the FTP issue but introduces instability from unpredictable image changes — which is why the digest was pinned in the first place.

Both strategies are a dead end. This PR eliminates the runtime `tlmgr` dependency entirely by installing pandoc and the required LaTeX packages (`texlive-latex-extra`, `texlive-fonts-extra`, `texlive-fonts-recommended`) via `apt` on the ubuntu runner. Ubuntu LTS repos are stable, require no runtime mirror access, and version with the runner image rather than with TeX Live's release cycle.


### Related Issue/Ticket

_Link GitHub issue or provide Jira ID._

### Testing

_If applicable: How did you verify the change? Include commands, data, or screenshots._

### Reviewer Notes

_Anything that helps reviewers (e.g. areas needing close attention)._

---

Once all boxes are checked, mark the PR as **Ready for Review** and tag at least one team member as the initial reviewer.
